### PR TITLE
Handles 404 in `/user/<id>`

### DIFF
--- a/githound.ps1
+++ b/githound.ps1
@@ -311,6 +311,7 @@ function Git-HoundUser
         try {
             $user_details = Invoke-GithubRestMethod -Session $Session -Path "user/$($user.id)"
         } catch {
+            Write-Verbose "User $($user.login) could not be found via api"
             continue
         }
 


### PR DESCRIPTION
Had a case where a user was returned from `orgs/<org>/members` but wasn't able to be pulled from `/user/<id>`, so skipping and logging to allow the run to complete.