### PR TITLE
Feat / Added EntraId SAML issuer string 

### DIFF
--- a/githound.ps1
+++ b/githound.ps1
@@ -1387,7 +1387,6 @@ query SAML($login: String!, $count: Int = 100, $after: String = null) {
                 }
             }
             {$_ -like 'https://login.microsoftonline.com/*' -or $_ -like 'https://sts.windows.net/*'} {
-                # This is to catch the Entra SSO cases, I just currently don't have an example of the issuer string
                 foreach($identity in $result.data.organization.samlIdentityProvider.externalIdentities.nodes)
                 {
                     foreach($attribute in $identity.samlIdentity.attributes)

--- a/githound.ps1
+++ b/githound.ps1
@@ -1386,7 +1386,7 @@ query SAML($login: String!, $count: Int = 100, $after: String = null) {
                     }
                 }
             }
-            'https://login.microsoftonline.com/*' {
+            {$_ -like 'https://login.microsoftonline.com/*' -or $_ -like 'https://sts.windows.net/*'} {
                 # This is to catch the Entra SSO cases, I just currently don't have an example of the issuer string
                 foreach($identity in $result.data.organization.samlIdentityProvider.externalIdentities.nodes)
                 {


### PR DESCRIPTION
Added the EntraId issuer string `https://sts.windows.net/*` case to switch statement when looking for SAML configurations. According to this [EntraId SAML Documentation](https://learn.microsoft.com/en-us/entra/identity-platform/single-sign-on-saml-protocol), it seems like both  `https://sts.windows.net/*` and `https://login.microsoftonline.com/*` are valid issuer strings. In my case, only `https://sts.windows.net/*` seems to work.