### PR TITLE
Add self-hosted runner modeling and workflow dispatch analysis

### DIFF
--- a/Documentation/EdgeDescriptions/GH_CanDispatchTo.md
+++ b/Documentation/EdgeDescriptions/GH_CanDispatchTo.md
@@ -1,0 +1,26 @@
+# GH_CanDispatchTo
+
+## Edge Schema
+
+- Source: [GH_WorkflowJob](../NodeDescriptions/GH_WorkflowJob.md)
+- Destination: [GH_OrgRunner](../NodeDescriptions/GH_OrgRunner.md), [GH_RepoRunner](../NodeDescriptions/GH_RepoRunner.md)
+
+## General Information
+
+The non-traversable [GH_CanDispatchTo](GH_CanDispatchTo.md) edge indicates that a workflow job's `runs-on` declaration matches a specific self-hosted runner that the owning repository is already allowed to use. It is computed by `Get-WorkflowRunnerDispatchEdges` from three pieces of evidence:
+
+- the job declares `self-hosted` in `runs_on`
+- the repository has a [GH_CanUseRunner](GH_CanUseRunner.md) edge to the runner
+- the runner's labels satisfy every requested `runs_on` label
+
+This edge is intentionally non-traversable for now. It records scheduler eligibility and configuration evidence, but does not by itself prove a reliable exploit or control path to the runner.
+
+```mermaid
+graph LR
+    job("GH_WorkflowJob build")
+    orgrunner("GH_OrgRunner org-linux-01")
+    reporunner("GH_RepoRunner repo-mac-01")
+
+    job -- GH_CanDispatchTo --> orgrunner
+    job -- GH_CanDispatchTo --> reporunner
+```

--- a/Documentation/EdgeDescriptions/GH_CanUseRunner.md
+++ b/Documentation/EdgeDescriptions/GH_CanUseRunner.md
@@ -1,0 +1,24 @@
+# GH_CanUseRunner
+
+## Edge Schema
+
+- Source: [GH_Repository](../NodeDescriptions/GH_Repository.md)
+- Destination: [GH_OrgRunner](../NodeDescriptions/GH_OrgRunner.md), [GH_RepoRunner](../NodeDescriptions/GH_RepoRunner.md)
+
+## General Information
+
+The non-traversable [GH_CanUseRunner](GH_CanUseRunner.md) edge indicates that a repository can dispatch GitHub Actions jobs to a specific self-hosted runner. It is created by `Git-HoundRunner` from either repository-scoped runner registration or organization runner-group access resolution. The destination runner node will be either [GH_OrgRunner](../NodeDescriptions/GH_OrgRunner.md) or [GH_RepoRunner](../NodeDescriptions/GH_RepoRunner.md).
+
+This edge is intentionally non-traversable for now. It captures repository-level runner access policy rather than a fully proven execution or compromise path.
+
+This edge is traversable because a principal that can execute arbitrary workflow code in the repository can cause that code to run on the target runner, making the runner a meaningful execution and lateral movement target in attack-path analysis.
+
+```mermaid
+graph LR
+    repo("GH_Repository app-service")
+    orgrunner("GH_OrgRunner org-linux-01")
+    reporunner("GH_RepoRunner repo-mac-01")
+
+    repo -- GH_CanUseRunner --> orgrunner
+    repo -- GH_CanUseRunner --> reporunner
+```

--- a/Documentation/NodeDescriptions/GH_OrgRunner.md
+++ b/Documentation/NodeDescriptions/GH_OrgRunner.md
@@ -1,0 +1,37 @@
+# GH_OrgRunner
+
+Represents a GitHub Actions self-hosted runner registered at the organization scope. These runners are typically made available to repositories through runner groups.
+
+Created by: `Git-HoundRunner`
+
+## Properties
+
+| Property Name         | Data Type | Description |
+| --------------------- | --------- | ----------- |
+| objectid              | string    | Synthetic graph identifier for the runner node in the form `{orgNodeId}_org_runner_{runnerId}`. |
+| name                  | string    | The runner name shown in GitHub Actions settings. |
+| node_id               | string    | Same as objectid. |
+| environment_name      | string    | The organization login that owns the runner. |
+| environmentid         | string    | The organization node_id. |
+| runner_id             | integer   | The numeric GitHub runner ID. |
+| os                    | string    | The operating system reported by the runner, such as `linux` or `macos`. |
+| status                | string    | The runner status, such as `online` or `offline`. |
+| busy                  | boolean   | Whether the runner is currently processing a job. |
+| ephemeral             | boolean   | Whether the runner is ephemeral and intended for single-job use. |
+| runner_group_id       | integer   | The numeric ID of the runner group that contains the runner. |
+| runner_group_name     | string    | The name of the runner group that contains the runner. |
+| labels                | string    | JSON-serialized runner labels, including default and custom labels. |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Organization[fa:fa-building GH_Organization]
+    GH_RunnerGroup[fa:fa-users-rectangle GH_RunnerGroup]
+    GH_OrgRunner[fa:fa-server GH_OrgRunner]
+    GH_Repository[fa:fa-box-archive GH_Repository]
+
+    GH_Organization -.->|GH_Contains| GH_RunnerGroup
+    GH_RunnerGroup -.->|GH_Contains| GH_OrgRunner
+    GH_Repository -->|GH_CanUseRunner| GH_OrgRunner
+```

--- a/Documentation/NodeDescriptions/GH_Organization.md
+++ b/Documentation/NodeDescriptions/GH_Organization.md
@@ -11,6 +11,7 @@ Created by: `Git-HoundOrganization`
 | objectid                                                     | string    | The GitHub `node_id` of the organization, used as the unique graph identifier.                                                                                                                |
 | id                                                           | integer   | The numeric GitHub ID of the organization.                                                                                                                                                    |
 | name                                                         | string    | The organization's login handle, used as the display name.                                                                                                                                    |
+| collected                                                    | boolean   | Marker property indicating that this organization node came from an actual GitHound collection rather than being synthesized or inferred.                                                   |
 | login                                                        | string    | The organization's login handle (URL slug).                                                                                                                                                   |
 | node_id                                                      | string    | The GitHub GraphQL node ID. Redundant with objectid.                                                                                                                                          |
 | description                                                  | string    | The organization's description.                                                                                                                                                               |
@@ -67,6 +68,7 @@ Created by: `Git-HoundOrganization`
 | actions_enabled_repositories                                 | string    | Which repositories have GitHub Actions enabled: `all`, `selected`, or `none`.                                                                                                                 |
 | actions_allowed_actions                                      | string    | Which Actions are allowed to run: `all`, `local_only`, or `selected`.                                                                                                                         |
 | actions_sha_pinning_required                                 | boolean   | Whether SHA pinning is required for GitHub Actions.                                                                                                                                           |
+| self_hosted_runners_enabled_repositories                     | string    | Which repositories are allowed to use self-hosted runners in the organization: `all`, `selected`, or `none`.                                                                                |
 
 ## Diagram
 
@@ -74,6 +76,8 @@ Created by: `Git-HoundOrganization`
 flowchart TD
     GH_Organization[fa:fa-building GH_Organization]
     GH_Repository[fa:fa-box-archive GH_Repository]
+    GH_RunnerGroup[fa:fa-users-rectangle GH_RunnerGroup]
+    GH_OrgRunner[fa:fa-server GH_OrgRunner]
     GH_OrgSecret[fa:fa-lock GH_OrgSecret]
     GH_SamlIdentityProvider[fa:fa-id-badge GH_SamlIdentityProvider]
     GH_OrgRole[fa:fa-user-tie GH_OrgRole]
@@ -85,6 +89,8 @@ flowchart TD
 
 
     GH_Organization -.->|GH_Contains| GH_OrgSecret
+    GH_Organization -.->|GH_Contains| GH_RunnerGroup
+    GH_RunnerGroup -.->|GH_Contains| GH_OrgRunner
     GH_Organization -.->|GH_HasSamlIdentityProvider| GH_SamlIdentityProvider
     GH_Organization -.->|GH_Contains| GH_PersonalAccessToken
     GH_Organization -.->|GH_Contains| GH_PersonalAccessTokenRequest

--- a/Documentation/NodeDescriptions/GH_RepoRunner.md
+++ b/Documentation/NodeDescriptions/GH_RepoRunner.md
@@ -1,0 +1,35 @@
+# GH_RepoRunner
+
+Represents a GitHub Actions self-hosted runner registered directly to a repository.
+
+Created by: `Git-HoundRunner`
+
+## Properties
+
+| Property Name         | Data Type | Description |
+| --------------------- | --------- | ----------- |
+| objectid              | string    | Synthetic graph identifier for the runner node in the form `{repoNodeId}_repo_runner_{runnerId}`. |
+| name                  | string    | The runner name shown in GitHub Actions settings. |
+| node_id               | string    | Same as objectid. |
+| environment_name      | string    | The organization login that owns the repository. |
+| environmentid         | string    | The organization node_id. |
+| runner_id             | integer   | The numeric GitHub runner ID. |
+| repository_name       | string    | The repository name that owns the runner. |
+| repository_id         | string    | The repository node_id that owns the runner. |
+| repository_full_name  | string    | The fully-qualified repository name. |
+| os                    | string    | The operating system reported by the runner, such as `linux` or `macos`. |
+| status                | string    | The runner status, such as `online` or `offline`. |
+| busy                  | boolean   | Whether the runner is currently processing a job. |
+| ephemeral             | boolean   | Whether the runner is ephemeral and intended for single-job use. |
+| labels                | string    | JSON-serialized runner labels, including default and custom labels. |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Repository[fa:fa-box-archive GH_Repository]
+    GH_RepoRunner[fa:fa-server GH_RepoRunner]
+
+    GH_Repository -.->|GH_Contains| GH_RepoRunner
+    GH_Repository -->|GH_CanUseRunner| GH_RepoRunner
+```

--- a/Documentation/NodeDescriptions/GH_Repository.md
+++ b/Documentation/NodeDescriptions/GH_Repository.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_repository.png" width="50"/> GH_Repository
 
-Represents a GitHub repository within the organization. Repository nodes capture metadata about the repo including visibility, Actions enablement status, and security configuration. Repository role nodes (GH_RepoRole) are created alongside each repository to represent the permission levels available.
+Represents a GitHub repository within the organization. Repository nodes capture metadata about the repo including visibility, Actions enablement status, self-hosted runner eligibility, and security configuration. Repository role nodes (GH_RepoRole) are created alongside each repository to represent the permission levels available.
 
 Created by: `Git-HoundRepository`
 
@@ -35,6 +35,7 @@ Created by: `Git-HoundRepository`
 | watchers                    | integer   | Number of watchers.                                                          |
 | default_branch              | string    | The name of the default branch (e.g., `main`).                               |
 | actions_enabled             | boolean   | Whether GitHub Actions is enabled for this repository.                       |
+| self_hosted_runners_enabled | boolean   | Whether this repository is currently allowed to use self-hosted runners under the organization's runner policy. |
 | secret_scanning             | string    | Status of secret scanning (e.g., `enabled`, `disabled`).                     |
 
 ## Diagram
@@ -46,6 +47,8 @@ flowchart TD
     GH_Branch[fa:fa-code-branch GH_Branch]
     GH_Workflow[fa:fa-cogs GH_Workflow]
     GH_Environment[fa:fa-leaf GH_Environment]
+    GH_OrgRunner[fa:fa-server GH_OrgRunner]
+    GH_RepoRunner[fa:fa-server GH_RepoRunner]
     GH_OrgSecret[fa:fa-lock GH_OrgSecret]
     GH_RepoSecret[fa:fa-lock GH_RepoSecret]
     GH_OrgVariable[fa:fa-lock-open GH_OrgVariable]
@@ -62,10 +65,13 @@ flowchart TD
     GH_Repository -.->|GH_HasBranch| GH_Branch
     GH_Repository -.->|GH_HasWorkflow| GH_Workflow
     GH_Repository -.->|GH_HasEnvironment| GH_Environment
+    GH_Repository -.->|GH_Contains| GH_RepoRunner
     GH_Repository -->|GH_HasSecret| GH_OrgSecret
     GH_Repository -->|GH_HasSecret| GH_RepoSecret
     GH_Repository -->|GH_HasVariable| GH_OrgVariable
     GH_Repository -->|GH_HasVariable| GH_RepoVariable
+    GH_Repository -.->|GH_CanUseRunner| GH_OrgRunner
+    GH_Repository -.->|GH_CanUseRunner| GH_RepoRunner
     GH_Repository -.->|GH_Contains| GH_RepoSecret
     GH_Repository -.->|GH_Contains| GH_RepoVariable
     GH_Repository -.->|GH_Contains| GH_SecretScanningAlert

--- a/Documentation/NodeDescriptions/GH_RunnerGroup.md
+++ b/Documentation/NodeDescriptions/GH_RunnerGroup.md
@@ -1,0 +1,36 @@
+# GH_RunnerGroup
+
+Represents an organization-level self-hosted runner group. Runner groups are the policy boundary that determines which repositories may use organization-scoped runners.
+
+Created by: `Git-HoundRunner`
+
+## Properties
+
+| Property Name               | Data Type | Description |
+| --------------------------- | --------- | ----------- |
+| objectid                    | string    | Synthetic graph identifier for the runner group node in the form `{orgNodeId}_runner_group_{groupId}`. |
+| name                        | string    | Fully-qualified runner group name in the form `org/group`. |
+| node_id                     | string    | Same as objectid. |
+| environment_name            | string    | The organization login that owns the runner group. |
+| environmentid               | string    | The organization node_id. |
+| group_id                    | integer   | The numeric GitHub runner group ID. |
+| group_name                  | string    | The runner group name. |
+| visibility                  | string    | Which repositories may access the group: typically `all`, `selected`, or `private`. |
+| default                     | boolean   | Whether this is the default runner group. |
+| inherited                   | boolean   | Whether the group is inherited from a higher scope. |
+| allows_public_repositories  | boolean   | Whether public repositories may access the group. |
+| restricted_to_workflows     | boolean   | Whether access is restricted to a selected set of workflows. |
+| selected_workflows          | string    | JSON-serialized list of workflow paths allowed to use the group when workflow restrictions are enabled. |
+| runners_url                 | string    | API URL for the group's runner membership. |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Organization[fa:fa-building GH_Organization]
+    GH_RunnerGroup[fa:fa-users-rectangle GH_RunnerGroup]
+    GH_OrgRunner[fa:fa-server GH_OrgRunner]
+
+    GH_Organization -.->|GH_Contains| GH_RunnerGroup
+    GH_RunnerGroup -.->|GH_Contains| GH_OrgRunner
+```

--- a/Documentation/NodeDescriptions/GH_WorkflowJob.md
+++ b/Documentation/NodeDescriptions/GH_WorkflowJob.md
@@ -27,10 +27,14 @@ flowchart TD
     GH_WorkflowJob[fa:fa-layer-group GH_WorkflowJob]
     GH_WorkflowStep[fa:fa-circle-dot GH_WorkflowStep]
     GH_Environment[fa:fa-leaf GH_Environment]
+    GH_OrgRunner[fa:fa-server GH_OrgRunner]
+    GH_RepoRunner[fa:fa-server GH_RepoRunner]
 
     GH_Workflow -.->|GH_HasJob| GH_WorkflowJob
     GH_WorkflowJob -.->|GH_HasStep| GH_WorkflowStep
     GH_WorkflowJob -.->|GH_DeploysTo| GH_Environment
+    GH_WorkflowJob -.->|GH_CanDispatchTo| GH_OrgRunner
+    GH_WorkflowJob -.->|GH_CanDispatchTo| GH_RepoRunner
     GH_WorkflowJob -.->|GH_DependsOn| GH_WorkflowJob
     GH_WorkflowJob -.->|GH_CallsWorkflow| GH_Workflow
 ```

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -31,9 +31,12 @@
 | ![GH_PersonalAccessToken](Icons/gh_personalaccesstoken.png) | [GH_PersonalAccessToken](NodeDescriptions/GH_PersonalAccessToken.md) | GitHub Personal Access Token |
 | ![GH_PersonalAccessTokenRequest](Icons/gh_personalaccesstokenrequest.png) | [GH_PersonalAccessTokenRequest](NodeDescriptions/GH_PersonalAccessTokenRequest.md) | GitHub Personal Access Token Request |
 | ![GH_RepoRole](Icons/gh_reporole.png) | [GH_RepoRole](NodeDescriptions/GH_RepoRole.md) | GitHub Repo Role |
+| ![GH_RepoRunner](Icons/gh_reporunner.png) | [GH_RepoRunner](NodeDescriptions/GH_RepoRunner.md) | GitHub Repo Self-Hosted Runner |
 | ![GH_RepoSecret](Icons/gh_reposecret.png) | [GH_RepoSecret](NodeDescriptions/GH_RepoSecret.md) | GitHub Repo Secret |
 | ![GH_Repository](Icons/gh_repository.png) | [GH_Repository](NodeDescriptions/GH_Repository.md) | GitHub Repository |
 | ![GH_RepoVariable](Icons/gh_repovariable.png) | [GH_RepoVariable](NodeDescriptions/GH_RepoVariable.md) | GitHub Repo Variable |
+| ![GH_OrgRunner](Icons/gh_orgrunner.png) | [GH_OrgRunner](NodeDescriptions/GH_OrgRunner.md) | GitHub Org Self-Hosted Runner |
+| ![GH_RunnerGroup](Icons/gh_runnergroup.png) | [GH_RunnerGroup](NodeDescriptions/GH_RunnerGroup.md) | GitHub Runner Group |
 | ![GH_SamlIdentityProvider](Icons/gh_samlidentityprovider.png) | [GH_SamlIdentityProvider](NodeDescriptions/GH_SamlIdentityProvider.md) | GitHub SAML Identity Provider |
 | ![GH_SecretScanningAlert](Icons/gh_secretscanningalert.png) | [GH_SecretScanningAlert](NodeDescriptions/GH_SecretScanningAlert.md) | GitHub Secret Scanning Alert |
 | ![GH_Team](Icons/gh_team.png) | [GH_Team](NodeDescriptions/GH_Team.md) | GitHub Team |
@@ -56,6 +59,8 @@
 | [GH_BypassPullRequestAllowances](EdgeDescriptions/GH_BypassPullRequestAllowances.md) | ❌ | User or team can bypass pull request requirements on a branch protection rule |
 | [GH_CanAccess](EdgeDescriptions/GH_CanAccess.md) | ❌ | Personal access token or app installation can access this repository or organization |
 | [GH_CanAssumeIdentity](EdgeDescriptions/GH_CanAssumeIdentity.md) | ✅ | Repository can assume this cloud identity via OIDC federation (Azure workload identity or AWS IAM role) |
+| [GH_CanDispatchTo](EdgeDescriptions/GH_CanDispatchTo.md) | ❌ | [Workflow] Job can dispatch to this self-hosted runner based on runs-on label matching and repository runner access |
+| [GH_CanUseRunner](EdgeDescriptions/GH_CanUseRunner.md) | ❌ | [Actions] Repository can dispatch jobs to this self-hosted runner |
 | [GH_CanCreateBranch](EdgeDescriptions/GH_CanCreateBranch.md) | ✅ | [Repository - Computed] Role can create new branches in this repository (unprotected branches that bypass the merge gate) |
 | [GH_CanEditProtection](EdgeDescriptions/GH_CanEditProtection.md) | ✅ | [Repository - Computed] Repo role can modify or remove branch protection rules in this repository, with supporting branch-level edges for impacted protected branches |
 | [GH_CanPwnRequest](EdgeDescriptions/GH_CanPwnRequest.md) | ✅ | [Computed] Repo role can exploit a pwn-requestable workflow to execute arbitrary code with the target's secrets and permissions |

--- a/Parse-GitHoundWorkflow.ps1
+++ b/Parse-GitHoundWorkflow.ps1
@@ -104,6 +104,161 @@ function Add-GitHoundVariableEdges
     }
 }
 
+function Get-WorkflowRunsOnLabels
+{
+    param(
+        [Parameter()]
+        $RunsOn
+    )
+
+    if (-not $RunsOn) { return @() }
+
+    if ($RunsOn -is [System.Collections.IList]) {
+        return @($RunsOn | ForEach-Object { "$_".Trim() } | Where-Object { $_ })
+    }
+
+    if ($RunsOn -isnot [string]) {
+        return @("$RunsOn".Trim() | Where-Object { $_ })
+    }
+
+    $trimmed = $RunsOn.Trim()
+    if (-not $trimmed) { return @() }
+
+    if ($trimmed.StartsWith('[') -or $trimmed.StartsWith('{')) {
+        $parsed = try { $trimmed | ConvertFrom-Json -ErrorAction SilentlyContinue } catch { $null }
+        if ($parsed -is [System.Collections.IList]) {
+            return @($parsed | ForEach-Object { "$_".Trim() } | Where-Object { $_ })
+        }
+    }
+
+    return @($trimmed)
+}
+
+function Get-RunnerLabelNames
+{
+    param(
+        [Parameter()]
+        $Labels
+    )
+
+    if (-not $Labels) { return @() }
+
+    $parsed = $Labels
+    if ($Labels -is [string]) {
+        $parsed = try { $Labels | ConvertFrom-Json -ErrorAction SilentlyContinue } catch { $Labels }
+    }
+
+    if ($parsed -is [System.Collections.IList]) {
+        return @($parsed | ForEach-Object {
+            if ($_ -is [string]) { "$_".Trim() }
+            elseif ($_ -and $_.name) { "$($_.name)".Trim() }
+        } | Where-Object { $_ })
+    }
+
+    return @()
+}
+
+function Get-WorkflowRunnerDispatchEdges
+{
+    <#
+    .SYNOPSIS
+        Computes GH_CanDispatchTo edges from workflow jobs to matching self-hosted runners.
+
+    .DESCRIPTION
+        Resolves a workflow job's runs-on labels against the set of runners the owning repository
+        can use via GH_CanUseRunner. Only self-hosted jobs are considered.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)]
+        [PSObject]$GraphData,
+
+        [Parameter(Mandatory)]
+        [PSObject]$WorkflowData
+    )
+
+    $edges = New-Object System.Collections.ArrayList
+
+    $graphNodes = @($GraphData.graph.nodes ?? @())
+    $graphEdges = @($GraphData.graph.edges ?? @())
+    $workflowNodes = @($WorkflowData.Nodes ?? @())
+    $workflowEdges = @($WorkflowData.Edges ?? @())
+
+    $jobNodes = @($workflowNodes | Where-Object { $_.kinds -contains 'GH_WorkflowJob' })
+    $jobEdges = @($workflowEdges | Where-Object { $_.kind -eq 'GH_HasJob' })
+    $repoWorkflowEdges = @($graphEdges | Where-Object { $_.kind -eq 'GH_HasWorkflow' })
+    $repoRunnerEdges = @($graphEdges | Where-Object { $_.kind -eq 'GH_CanUseRunner' })
+    $runnerNodes = @($graphNodes | Where-Object { $_.kinds -contains 'GH_Runner' })
+
+    $workflowToRepoId = @{}
+    foreach ($edge in $repoWorkflowEdges) {
+        if (-not $edge.start.value -or -not $edge.end.value) { continue }
+        $workflowToRepoId[$edge.end.value] = $edge.start.value
+    }
+
+    $jobToWorkflowId = @{}
+    foreach ($edge in $jobEdges) {
+        if (-not $edge.start.value -or -not $edge.end.value) { continue }
+        $jobToWorkflowId[$edge.end.value] = $edge.start.value
+    }
+
+    $repoToRunnerIds = @{}
+    foreach ($edge in $repoRunnerEdges) {
+        $repoId = $edge.start.value
+        $runnerId = $edge.end.value
+        if (-not $repoId -or -not $runnerId) { continue }
+        if (-not $repoToRunnerIds.ContainsKey($repoId)) {
+            $repoToRunnerIds[$repoId] = New-Object System.Collections.ArrayList
+        }
+        $null = $repoToRunnerIds[$repoId].Add($runnerId)
+    }
+
+    $runnerById = @{}
+    foreach ($runner in $runnerNodes) {
+        $runnerById[$runner.id] = $runner
+    }
+
+    foreach ($job in $jobNodes) {
+        $requiredLabels = @(Get-WorkflowRunsOnLabels -RunsOn $job.properties.runs_on)
+        if ($requiredLabels.Count -eq 0 -or $requiredLabels -notcontains 'self-hosted') { continue }
+
+        $workflowId = $jobToWorkflowId[$job.id]
+        if (-not $workflowId) { continue }
+
+        $repoId = $workflowToRepoId[$workflowId]
+        if (-not $repoId -or -not $repoToRunnerIds.ContainsKey($repoId)) { continue }
+
+        foreach ($runnerId in $repoToRunnerIds[$repoId]) {
+            if (-not $job.id -or -not $runnerId) { continue }
+            if (-not $runnerById.ContainsKey($runnerId)) { continue }
+            $runner = $runnerById[$runnerId]
+            $runnerLabels = @(Get-RunnerLabelNames -Labels $runner.properties.labels)
+            if ($runnerLabels.Count -eq 0) { continue }
+
+            $allMatched = $true
+            foreach ($label in $requiredLabels) {
+                if ($runnerLabels -notcontains $label) {
+                    $allMatched = $false
+                    break
+                }
+            }
+            if (-not $allMatched) { continue }
+
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_CanDispatchTo' -StartId $job.id -EndId $runnerId -Properties @{
+                traversable = $false
+                required_labels = ($requiredLabels | ConvertTo-Json -Compress)
+                matched_labels = ($runnerLabels | Where-Object { $requiredLabels -contains $_ } | ConvertTo-Json -Compress)
+                runner_scope = $runner.properties.scope
+            }))
+        }
+    }
+
+    [PSCustomObject]@{
+        Nodes = @()
+        Edges = $edges
+    }
+}
+
 function Test-PwnRequestable
 {
     <#
@@ -929,11 +1084,12 @@ function Invoke-GitHoundWorkflowAnalysis
     # Parse workflows
     $wfResult = Parse-GitHoundWorkflow -Workflows $workflowNodes
 
-    # Compute pwn request edges
+    # Compute pwn request and runner dispatch edges
     $pwnResult = Get-PwnRequestEdges -GraphData $data -WorkflowData $wfResult
+    $dispatchResult = Get-WorkflowRunnerDispatchEdges -GraphData $data -WorkflowData $wfResult
 
     # Combine and convert to BHOG
-    $payload = $wfResult, $pwnResult | ConvertTo-BHOG
+    $payload = $wfResult, $pwnResult, $dispatchResult | ConvertTo-BHOG
     $json = $payload | ConvertTo-Json -Depth 10
 
     # Determine output path
@@ -950,7 +1106,8 @@ function Invoke-GitHoundWorkflowAnalysis
     $pwnCount = @($wfResult.Nodes | Where-Object {
         $_.kinds -contains 'GH_Workflow' -and $_.properties.is_pwn_requestable -eq $true
     }).Count
-    Write-Host "[+] Summary: $($wfResult.Nodes.Count) nodes, $($wfResult.Edges.Count + $pwnResult.Edges.Count) edges, $pwnCount pwn-requestable workflow(s)"
+    $dispatchCount = @($dispatchResult.Edges).Count
+    Write-Host "[+] Summary: $($wfResult.Nodes.Count) nodes, $($wfResult.Edges.Count + $pwnResult.Edges.Count + $dispatchCount) edges, $pwnCount pwn-requestable workflow(s), $dispatchCount job-to-runner dispatch edge(s)"
 }
 
 function ConvertTo-BHOG

--- a/githound.ps1
+++ b/githound.ps1
@@ -104,8 +104,9 @@ function New-GitHubJwtSession
         $PrivateKeyPath,
 
         [Parameter(Position=3, Mandatory = $true)]
+        [Alias('AppId')]
         [string]
-        $AppId
+        $InstallationId
     )
 
     $header = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -InputObject @{
@@ -128,7 +129,7 @@ function New-GitHubJwtSession
     
     $jwtsession = New-GithubSession -OrganizationName $OrganizationName -Token $jwt
 
-    $result = Invoke-GithubrestMethod -Session $jwtsession -Path "app/installations/$($AppId)/access_tokens" -Method POST 
+    $result = Invoke-GithubrestMethod -Session $jwtsession -Path "app/installations/$($InstallationId)/access_tokens" -Method POST
 
     $session = New-GitHubSession -OrganizationName $OrganizationName -Token $result.token
     
@@ -500,11 +501,11 @@ function New-GitHoundEdge
         [String]
         $Kind,
 
-        [Parameter(Position = 1, Mandatory = $true)]
+        [Parameter(Position = 1, Mandatory = $false)]
         [PSObject]
         $StartId,
 
-        [Parameter(Position = 2, Mandatory = $true)]
+        [Parameter(Position = 2, Mandatory = $false)]
         [PSObject]
         $EndId,
 
@@ -538,6 +539,14 @@ function New-GitHoundEdge
         [Hashtable]
         $Properties = @{}
     )
+
+    if (-not $PSBoundParameters.ContainsKey('StartPropertyMatchers') -and -not $PSBoundParameters.ContainsKey('StartId')) {
+        throw "New-GitHoundEdge requires either StartId or StartPropertyMatchers."
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('EndPropertyMatchers') -and -not $PSBoundParameters.ContainsKey('EndId')) {
+        throw "New-GitHoundEdge requires either EndId or EndPropertyMatchers."
+    }
 
     $startEndpoint = if ($PSBoundParameters.ContainsKey('StartPropertyMatchers')) {
         $ep = @{ match_by = 'property'; property_matchers = $StartPropertyMatchers }
@@ -743,6 +752,7 @@ function Git-HoundOrganization
         API Reference:
         - Get an organization: https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#get-an-organization
         - Get GitHub Actions permissions for an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#get-github-actions-permissions-for-an-organization
+        - Get self-hosted runners settings for an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#get-self-hosted-runners-settings-for-an-organization
         - Get all organization roles for an organization: https://docs.github.com/en/rest/orgs/organization-roles?apiVersion=2022-11-28#get-all-organization-roles-for-an-organization
         - List teams that are assigned to an organization role: https://docs.github.com/en/rest/orgs/organization-roles?apiVersion=2022-11-28#list-teams-that-are-assigned-to-an-organization-role
         - List users that are assigned to an organization role: https://docs.github.com/en/rest/orgs/organization-roles?apiVersion=2022-11-28#list-users-that-are-assigned-to-an-organization-role
@@ -770,11 +780,13 @@ function Git-HoundOrganization
     $org = Invoke-GithubRestMethod -Session $Session -Path "orgs/$($Session.OrganizationName)"
     $actions = Invoke-GithubRestMethod -Session $session -Path "orgs/$($Session.OrganizationName)/actions/permissions"
     $workflowPerms = Invoke-GithubRestMethod -Session $session -Path "orgs/$($Session.OrganizationName)/actions/permissions/workflow"
+    $selfHostedRunnerSettings = Invoke-GithubRestMethod -Session $session -Path "orgs/$($Session.OrganizationName)/actions/permissions/self-hosted-runners"
 
     $properties = [pscustomobject]@{
         # Common Properties
         name                                                         = Normalize-Null $org.login
         node_id                                                      = Normalize-Null $org.node_id
+        collected                                                    = $true
         # Relational Properties
         environmentid                                                = Normalize-Null $org.node_id
         environment_name                                             = Normalize-Null $org.login
@@ -834,6 +846,7 @@ function Git-HoundOrganization
         actions_enabled_repositories                                 = Normalize-Null $actions.enabled_repositories
         actions_allowed_actions                                      = Normalize-Null $actions.allowed_actions
         actions_sha_pinning_required                                 = Normalize-Null $actions.sha_pinning_required
+        self_hosted_runners_enabled_repositories                     = Normalize-Null $selfHostedRunnerSettings.enabled_repositories
         default_workflow_permissions                                 = Normalize-Null $workflowPerms.default_workflow_permissions
         can_approve_pull_request_reviews                             = Normalize-Null $workflowPerms.can_approve_pull_request_reviews
         # Accordion Panel Queries
@@ -841,6 +854,8 @@ function Git-HoundOrganization
         query_users                                    = "MATCH (n:GH_User {environmentid:'$($org.node_id)'}) RETURN n"
         query_teams                                    = "MATCH (n:GH_Team {environmentid:'$($org.node_id)'}) RETURN n"
         query_repositories                             = "MATCH (n:GH_Repository {environmentid:'$($org.node_id)'}) RETURN n"
+        query_runner_groups                           = "MATCH p=(:GH_Organization {node_id:'$($org.node_id)'})-[:GH_Contains]->(:GH_RunnerGroup) RETURN p"
+        query_runners                                 = "MATCH p=(:GH_Organization {node_id:'$($org.node_id)'})-[:GH_Contains]->(:GH_RunnerGroup)-[:GH_Contains]->(:GH_Runner) RETURN p"
         query_personal_access_tokens                   = "MATCH p=(:GH_Organization {node_id: '$($org.node_id)'})-[:GH_Contains]->(token) WHERE token:GH_PersonalAccessToken OR token:GH_PersonalAccessTokenRequest RETURN p"
         query_secret_scanning_alerts                   = "MATCH p=(:GH_Organization {node_id: '$($org.node_id)'})-[:GH_Contains]->(alert:GH_SecretScanningAlert) RETURN p"
         query_identity_provider                        = "MATCH p=(OIP:GH_SamlIdentityProvider)-[:GH_HasExternalIdentity]->(EI:GH_ExternalIdentity) MATCH p1=(OIP)<-[:GH_HasSamlIdentityProvider]-(:GH_Organization {node_id:'$($org.node_id)'}) MATCH p2=(EI)-[:GH_MapsToUser]->() RETURN p,p1,p2"
@@ -1413,6 +1428,8 @@ function Git-HoundRepository
         API Reference:
         - Get GitHub Actions permissions for an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#get-github-actions-permissions-for-an-organization
         - List selected repositories enabled for GitHub Actions in an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#list-github-actions-enabled-repositories-for-an-organization
+        - Get self-hosted runners settings for an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#get-self-hosted-runners-settings-for-an-organization
+        - List repositories allowed to use self-hosted runners in an organization: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#list-repositories-allowed-to-use-self-hosted-runners-in-an-organization
         - List organization repositories: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-organization-repositories
         - List custom repository roles in an organization: https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2022-11-28#list-custom-repository-roles-in-an-organization
 
@@ -1447,11 +1464,18 @@ function Git-HoundRepository
 
     # Pre-loop setup: Actions permissions
     $actions = Invoke-GithubRestMethod -Session $session -Path "orgs/$($Organization.Properties.login)/actions/permissions"
+    $selfHostedRunnerSettings = Invoke-GithubRestMethod -Session $session -Path "orgs/$($Organization.Properties.login)/actions/permissions/self-hosted-runners"
 
     $enabledRepos = $null
     if($actions.enabled_repositories -ne 'all')
     {
         $enabledRepos = (Invoke-GithubRestMethod -Session $Session -Path "orgs/$($Organization.Properties.login)/actions/permissions/repositories").repositories.node_id
+    }
+
+    $selfHostedRunnerEnabledRepos = $null
+    if($selfHostedRunnerSettings.enabled_repositories -eq 'selected')
+    {
+        $selfHostedRunnerEnabledRepos = (Invoke-GithubRestMethod -Session $Session -Path "orgs/$($Organization.Properties.login)/actions/permissions/self-hosted-runners/repositories").repositories.node_id
     }
 
     # Pre-loop setup: Custom repository roles and org-level all_repo_* IDs
@@ -1471,7 +1495,9 @@ function Git-HoundRepository
         $Session = $using:Session
         $Organization = $using:Organization
         $actions = $using:actions
+        $selfHostedRunnerSettings = $using:selfHostedRunnerSettings
         $enabledRepos = $using:enabledRepos
+        $selfHostedRunnerEnabledRepos = $using:selfHostedRunnerEnabledRepos
         $customRepoRoles = $using:customRepoRoles
         $orgAllRepoReadId = $using:orgAllRepoReadId
         $orgAllRepoTriageId = $using:orgAllRepoTriageId
@@ -1493,6 +1519,19 @@ function Git-HoundRepository
         else
         {
             $actionsEnabled = $enabledRepos -contains $repo.node_id
+        }
+
+        if($selfHostedRunnerSettings.enabled_repositories -eq 'all')
+        {
+            $selfHostedRunnersEnabled = $true
+        }
+        elseif($selfHostedRunnerSettings.enabled_repositories -eq 'selected')
+        {
+            $selfHostedRunnersEnabled = $selfHostedRunnerEnabledRepos -contains $repo.node_id
+        }
+        else
+        {
+            $selfHostedRunnersEnabled = $false
         }
 
         $orgMembersId = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($Organization.id)_members"))
@@ -1527,6 +1566,7 @@ function Git-HoundRepository
             watchers                      = Normalize-Null $repo.watchers
             default_branch                = Normalize-Null $repo.default_branch
             actions_enabled               = Normalize-Null $actionsEnabled
+            self_hosted_runners_enabled   = Normalize-Null $selfHostedRunnersEnabled
             secret_scanning               = Normalize-Null $repo.security_and_analysis.secret_scanning.status
             # Accordion Panel Queries
             query_branches                = "MATCH p=(:GH_Repository {node_id: '$($repo.node_id)'})-[:GH_HasBranch]->(:GH_Branch) RETURN p"
@@ -1535,6 +1575,7 @@ function Git-HoundRepository
             query_roles                   = "MATCH p=(:GH_RepoRole)-[*1..2]->(:GH_Repository {node_id: '$($repo.node_id)'}) RETURN p"
             query_teams                   = "MATCH p=(:GH_Team)-[:GH_MemberOf|GH_HasRole*1..]->(:GH_RepoRole)-[]->(:GH_Repository {node_id: '$($repo.node_id)'}) RETURN p"
             query_workflows               = "MATCH p=(:GH_Repository {node_id:'$($repo.node_id)'})-[:GH_HasWorkflow]->(w:GH_Workflow) RETURN p"
+            query_runners                 = "MATCH p=(:GH_Repository {node_id:'$($repo.node_id)'})-[:GH_CanUseRunner]->(:GH_Runner) RETURN p"
             query_environments            = "MATCH p=(:GH_Repository {node_id: '$($repo.node_id)'})-[:GH_HasEnvironment]->(:GH_Environment) RETURN p"
             query_secrets                 = "MATCH p=(:GH_Repository {node_id:'$($repo.node_id)'})-[:GH_HasSecret]->(:GH_Secret) RETURN p"
             query_variables               = "MATCH p=(:GH_Repository {node_id:'$($repo.node_id)'})-[:GH_HasVariable]->(:GH_Variable) RETURN p"
@@ -3786,39 +3827,45 @@ function Git-HoundWorkflow
 
                 foreach($workflow in (Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/actions/workflows").workflows)
                 {
+                    $isStaticWorkflowFile = $workflow.path -match '^\.github/workflows/[^/]+\.(?:yml|yaml)$'
+
                     # Download workflow file contents from the repository
                     # Try the default branch first, then fall back to other branches if not found
                     $workflowContent = $null
                     $workflowBranch = $null
-                    $contentsBasePath = "repos/$($repo.properties.full_name)/contents/$($workflow.path)"
-                    try {
-                        $contentResponse = Invoke-GithubRestMethod -Session $Session -Path $contentsBasePath -ErrorAction Stop
-                        if ($contentResponse.content) {
-                            $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
-                            $workflowBranch = $repo.properties.default_branch
-                        }
-                    } catch {
-                        # Workflow not on default branch — try other branches
+                    if ($isStaticWorkflowFile) {
+                        $contentsBasePath = "repos/$($repo.properties.full_name)/contents/$($workflow.path)"
                         try {
-                            $branches = Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/branches" -ErrorAction Stop
-                            foreach ($branch in $branches) {
-                                try {
-                                    $contentResponse = Invoke-GithubRestMethod -Session $Session -Path "$contentsBasePath`?ref=$($branch.name)" -ErrorAction Stop
-                                    if ($contentResponse.content) {
-                                        $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
-                                        $workflowBranch = $branch.name
-                                        break
-                                    }
-                                } catch {
-                                    continue
-                                }
+                            $contentResponse = Invoke-GithubRestMethod -Session $Session -Path $contentsBasePath -ErrorAction Stop
+                            if ($contentResponse.content) {
+                                $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
+                                $workflowBranch = $repo.properties.default_branch
                             }
                         } catch {
-                            Write-Warning "Could not list branches for $($repo.properties.full_name): $_"
+                            # Workflow not on default branch — try other branches
+                            try {
+                                $branches = Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/branches" -ErrorAction Stop
+                                foreach ($branch in $branches) {
+                                    try {
+                                        $contentResponse = Invoke-GithubRestMethod -Session $Session -Path "$contentsBasePath`?ref=$($branch.name)" -ErrorAction Stop
+                                        if ($contentResponse.content) {
+                                            $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
+                                            $workflowBranch = $branch.name
+                                            break
+                                        }
+                                    } catch {
+                                        continue
+                                    }
+                                }
+                            } catch {
+                                Write-Warning "Could not list branches for $($repo.properties.full_name): $_"
+                            }
+                            if (-not $workflowContent) {
+                                Write-Warning "Could not download workflow contents for $($repo.properties.full_name)/$($workflow.path) on any branch"
+                            }
                         }
-                        if (-not $workflowContent) {
-                            Write-Warning "Could not download workflow contents for $($repo.properties.full_name)/$($workflow.path) on any branch"
-                        }
+                    } else {
+                        Write-Verbose "Skipping content download for non-repo-backed or dynamic workflow '$($repo.properties.full_name)/$($workflow.path)'"
                     }
 
                     $props = [pscustomobject]@{
@@ -3915,6 +3962,239 @@ function Git-HoundWorkflow
         }
 
         Write-Output $output
+    }
+}
+
+function Git-HoundRunner
+{
+    <#
+    .SYNOPSIS
+        Fetches self-hosted runner groups and runners at the organization and repository scope.
+
+    .DESCRIPTION
+        This function models self-hosted runner access in two layers:
+        - Organization runner groups and the runners assigned to them
+        - Repository-level self-hosted runners registered directly to a repository
+
+        It emits explicit GH_CanUseRunner edges from repositories to the runners they can
+        dispatch jobs to, so access is represented directly in the graph without relying on
+        implicit policy interpretation at query time.
+
+        API Reference:
+        - List self-hosted runner groups for an organization: https://docs.github.com/en/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#list-self-hosted-runner-groups-for-an-organization
+        - List repository access to a self-hosted runner group in an organization: https://docs.github.com/en/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#list-repository-access-to-a-self-hosted-runner-group-in-an-organization
+        - List self-hosted runners in a group for an organization: https://docs.github.com/en/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#list-self-hosted-runners-in-a-group-for-an-organization
+        - List self-hosted runners for a repository: https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#list-self-hosted-runners-for-a-repository
+
+        Fine Grained Permissions Reference:
+        - "Self-hosted runners" organization permissions (read)
+        - "Administration" repository permissions (read)
+
+    .PARAMETER Session
+        A GitHound.Session object used for authentication and API requests.
+
+    .PARAMETER Organization
+        The GH_Organization node for the current collection.
+
+    .PARAMETER Repository
+        Repository output from Git-HoundRepository. Used to resolve repository access.
+    #>
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $true)]
+        [psobject]
+        $Organization,
+
+        [Parameter(Position = 2, Mandatory = $true, ValueFromPipeline)]
+        [psobject[]]
+        $Repository
+    )
+
+    begin
+    {
+        $nodes = New-Object System.Collections.ArrayList
+        $edges = New-Object System.Collections.ArrayList
+        $repoNodes = New-Object System.Collections.ArrayList
+    }
+
+    process
+    {
+        $Repository.nodes | Where-Object {$_.kinds -eq 'GH_Repository'} | ForEach-Object {
+            $null = $repoNodes.Add($_)
+        }
+    }
+
+    end
+    {
+        $orgLogin = $Session.OrganizationName
+        $orgNodeId = $Organization.id
+
+        $repoByNodeId = @{}
+        $allRepoIds = New-Object System.Collections.ArrayList
+        $privateRepoIds = New-Object System.Collections.ArrayList
+
+        foreach ($repoNode in $repoNodes) {
+            $repoByNodeId[$repoNode.properties.node_id] = $repoNode
+            $null = $allRepoIds.Add($repoNode.id)
+            if ($repoNode.properties.visibility -in @('private', 'internal')) {
+                $null = $privateRepoIds.Add($repoNode.id)
+            }
+        }
+
+        $seenRunnerNodeIds = @{}
+        $seenUseEdges = @{}
+
+        $runnerGroups = @()
+        try {
+            $runnerGroups = @((Invoke-GithubRestMethod -Session $Session -Path "orgs/$orgLogin/actions/runner-groups").runner_groups)
+        } catch {
+            Write-Warning "Could not enumerate organization runner groups for ${orgLogin}: $_"
+        }
+
+        foreach ($group in $runnerGroups) {
+            $groupNodeId = "$orgNodeId`_runner_group_$($group.id)"
+            $groupProperties = [pscustomobject]@{
+                name                       = Normalize-Null "$orgLogin/$($group.name)"
+                node_id                    = Normalize-Null $groupNodeId
+                environment_name           = Normalize-Null $orgLogin
+                environmentid              = Normalize-Null $Organization.properties.node_id
+                group_id                   = Normalize-Null $group.id
+                group_name                 = Normalize-Null $group.name
+                visibility                 = Normalize-Null $group.visibility
+                default                    = Normalize-Null $group.default
+                inherited                  = Normalize-Null $group.inherited
+                allows_public_repositories = Normalize-Null $group.allows_public_repositories
+                restricted_to_workflows    = Normalize-Null $group.restricted_to_workflows
+                selected_workflows         = Normalize-Null ($group.selected_workflows | ConvertTo-Json -Depth 10)
+                runners_url                = Normalize-Null $group.runners_url
+                query_runners              = "MATCH p=(:GH_RunnerGroup {node_id:'$groupNodeId'})-[:GH_Contains]->(:GH_OrgRunner) RETURN p"
+                query_repositories         = "MATCH p=(:GH_Repository)-[:GH_CanUseRunner]->(:GH_OrgRunner)<-[:GH_Contains]-(:GH_RunnerGroup {node_id:'$groupNodeId'}) RETURN p"
+            }
+            $null = $nodes.Add((New-GitHoundNode -Id $groupNodeId -Kind 'GH_RunnerGroup' -Properties $groupProperties))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $orgNodeId -EndId $groupNodeId -Properties @{ traversable = $false }))
+
+            $accessibleRepoIds = @()
+            switch ($group.visibility) {
+                'all' {
+                    $accessibleRepoIds = @($allRepoIds)
+                }
+                'private' {
+                    $accessibleRepoIds = @($privateRepoIds)
+                }
+                'selected' {
+                    try {
+                        $selectedRepos = @((Invoke-GithubRestMethod -Session $Session -Path "orgs/$orgLogin/actions/runner-groups/$($group.id)/repositories").repositories)
+                        $accessibleRepoIds = @($selectedRepos | Where-Object { $repoByNodeId.ContainsKey($_.node_id) } | ForEach-Object { $repoByNodeId[$_.node_id].id })
+                    } catch {
+                        Write-Warning "Could not enumerate selected repository access for runner group '$($group.name)' in ${orgLogin}: $_"
+                    }
+                }
+                default {
+                    $accessibleRepoIds = @()
+                }
+            }
+
+            $groupRunners = @()
+            try {
+                $groupRunners = @((Invoke-GithubRestMethod -Session $Session -Path "orgs/$orgLogin/actions/runner-groups/$($group.id)/runners").runners)
+            } catch {
+                Write-Warning "Could not enumerate runners for runner group '$($group.name)' in ${orgLogin}: $_"
+            }
+
+            foreach ($runner in $groupRunners) {
+                $runnerNodeId = "$orgNodeId`_org_runner_$($runner.id)"
+                if (-not $seenRunnerNodeIds.ContainsKey($runnerNodeId)) {
+                    $runnerProperties = [pscustomobject]@{
+                        name                 = Normalize-Null $runner.name
+                        node_id              = Normalize-Null $runnerNodeId
+                        environment_name     = Normalize-Null $orgLogin
+                        environmentid        = Normalize-Null $Organization.properties.node_id
+                        scope                = Normalize-Null 'organization'
+                        runner_id            = Normalize-Null $runner.id
+                        os                   = Normalize-Null $runner.os
+                        status               = Normalize-Null $runner.status
+                        busy                 = Normalize-Null $runner.busy
+                        ephemeral            = Normalize-Null $runner.ephemeral
+                        runner_group_id      = Normalize-Null $group.id
+                        runner_group_name    = Normalize-Null $group.name
+                        labels               = Normalize-Null ($runner.labels | ConvertTo-Json -Depth 10)
+                    }
+                    $null = $nodes.Add((New-GitHoundNode -Id $runnerNodeId -Kind @('GH_OrgRunner', 'GH_Runner') -Properties $runnerProperties))
+                    $seenRunnerNodeIds[$runnerNodeId] = $true
+                }
+
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $groupNodeId -EndId $runnerNodeId -Properties @{ traversable = $false }))
+
+                foreach ($repoId in $accessibleRepoIds) {
+                    $edgeKey = "$repoId|$runnerNodeId"
+                    if (-not $seenUseEdges.ContainsKey($edgeKey)) {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_CanUseRunner' -StartId $repoId -EndId $runnerNodeId -Properties @{
+                            traversable = $false
+                            scope = 'organization'
+                            via = 'runner_group'
+                            runner_group_name = $group.name
+                            runner_group_visibility = $group.visibility
+                        }))
+                        $seenUseEdges[$edgeKey] = $true
+                    }
+                }
+            }
+        }
+
+        $repoRunnerCandidates = @($repoNodes | Where-Object { $_.properties.actions_enabled -and $_.properties.self_hosted_runners_enabled })
+        foreach ($repoNode in $repoRunnerCandidates) {
+            $repoRunners = @()
+            try {
+                $repoRunners = @((Invoke-GithubRestMethod -Session $Session -Path "repos/$($repoNode.properties.full_name)/actions/runners").runners)
+            } catch {
+                Write-Warning "Could not enumerate repository runners for $($repoNode.properties.full_name): $_"
+            }
+
+            foreach ($runner in $repoRunners) {
+                $runnerNodeId = "$($repoNode.id)`_repo_runner_$($runner.id)"
+                if (-not $seenRunnerNodeIds.ContainsKey($runnerNodeId)) {
+                    $runnerProperties = [pscustomobject]@{
+                        name                 = Normalize-Null $runner.name
+                        node_id              = Normalize-Null $runnerNodeId
+                        environment_name     = Normalize-Null $orgLogin
+                        environmentid        = Normalize-Null $Organization.properties.node_id
+                        scope                = Normalize-Null 'repository'
+                        runner_id            = Normalize-Null $runner.id
+                        repository_name      = Normalize-Null $repoNode.properties.name
+                        repository_id        = Normalize-Null $repoNode.properties.node_id
+                        repository_full_name = Normalize-Null $repoNode.properties.full_name
+                        os                   = Normalize-Null $runner.os
+                        status               = Normalize-Null $runner.status
+                        busy                 = Normalize-Null $runner.busy
+                        ephemeral            = Normalize-Null $runner.ephemeral
+                        labels               = Normalize-Null ($runner.labels | ConvertTo-Json -Depth 10)
+                    }
+                    $null = $nodes.Add((New-GitHoundNode -Id $runnerNodeId -Kind @('GH_RepoRunner', 'GH_Runner') -Properties $runnerProperties))
+                    $seenRunnerNodeIds[$runnerNodeId] = $true
+                }
+
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $repoNode.id -EndId $runnerNodeId -Properties @{ traversable = $false }))
+
+                $edgeKey = "$($repoNode.id)|$runnerNodeId"
+                if (-not $seenUseEdges.ContainsKey($edgeKey)) {
+                    $null = $edges.Add((New-GitHoundEdge -Kind 'GH_CanUseRunner' -StartId $repoNode.id -EndId $runnerNodeId -Properties @{
+                        traversable = $false
+                        scope = 'repository'
+                        via = 'repository'
+                    }))
+                    $seenUseEdges[$edgeKey] = $true
+                }
+            }
+        }
+
+        Write-Host "[+] Git-HoundRunner complete. $($nodes.Count) nodes, $($edges.Count) edges."
+        [PSCustomObject]@{
+            Nodes = $nodes
+            Edges = $edges
+        }
     }
 }
 
@@ -5962,6 +6242,24 @@ function Invoke-GitHound
         if($workflows.edges) { $edges.AddRange(@($workflows.edges)) }
     } else {
         Write-Host "[*] Skipping Workflows (use -CollectAll to include)"
+    }
+
+    # ── Step 7.5: Self-Hosted Runners (requires -CollectAll) ──────────────
+    if ($CollectAll) {
+        $stepFile = Join-Path $CheckpointPath "githound_Runner_$orgId.json"
+        if ($Resume -and (Test-Path $stepFile)) {
+            Write-Host "[*] Resuming: Loaded Self-Hosted Runners from githound_Runner_$orgId.json"
+            $runners = Import-GitHoundStepOutput -FilePath $stepFile
+        } else {
+            Write-Host "[*] Enumerating Self-Hosted Runners"
+            $runners = $repos | Git-HoundRunner -Session $Session -Organization $org.nodes[0]
+            Export-GitHoundStepOutput -StepResult $runners -FilePath $stepFile
+            Write-Host "[+] Saved: githound_Runner_$orgId.json"
+        }
+        if($runners.nodes) { $nodes.AddRange(@($runners.nodes)) }
+        if($runners.edges) { $edges.AddRange(@($runners.edges)) }
+    } else {
+        Write-Host "[*] Skipping Self-Hosted Runners (use -CollectAll to include)"
     }
 
     # ── Step 8: Environments (requires -CollectAll) ───────────────────────

--- a/model.json
+++ b/model.json
@@ -133,6 +133,27 @@
         "color": "#E89B5C"
       }
     },
+    "GH_OrgRunner": {
+      "icon": {
+        "type": "font-awesome",
+        "name": "server",
+        "color": "#FFD580"
+      }
+    },
+    "GH_RepoRunner": {
+      "icon": {
+        "type": "font-awesome",
+        "name": "server",
+        "color": "#FFD580"
+      }
+    },
+    "GH_RunnerGroup": {
+      "icon": {
+        "type": "font-awesome",
+        "name": "users-rectangle",
+        "color": "#B4F8C8"
+      }
+    },
     "GH_SamlIdentityProvider": {
       "icon": {
         "type": "font-awesome",

--- a/schema.json
+++ b/schema.json
@@ -39,6 +39,38 @@
       "color": "#9EECFF"
     },
     {
+      "name": "GH_RunnerGroup",
+      "display_name": "GitHub Runner Group",
+      "description": "An organization-level self-hosted runner group that controls which repositories may use a set of runners",
+      "is_display_kind": true,
+      "icon": "users-rectangle",
+      "color": "#B4F8C8"
+    },
+    {
+      "name": "GH_Runner",
+      "display_name": "GitHub Self-Hosted Runner",
+      "description": "A generic self-hosted runner kind shared by organization-scoped and repository-scoped runner nodes",
+      "is_display_kind": false,
+      "icon": "server",
+      "color": "#FFD580"
+    },
+    {
+      "name": "GH_OrgRunner",
+      "display_name": "GitHub Org Self-Hosted Runner",
+      "description": "A self-hosted runner registered at the organization scope for GitHub Actions jobs",
+      "is_display_kind": true,
+      "icon": "server",
+      "color": "#FFD580"
+    },
+    {
+      "name": "GH_RepoRunner",
+      "display_name": "GitHub Repo Self-Hosted Runner",
+      "description": "A self-hosted runner registered directly to a repository for GitHub Actions jobs",
+      "is_display_kind": true,
+      "icon": "server",
+      "color": "#FFD580"
+    },
+    {
       "name": "GH_Branch",
       "display_name": "GitHub Branch",
       "description": "A named reference in a repository representing a line of development",
@@ -735,6 +767,16 @@
       "name": "GH_CanAssumeIdentity",
       "description": "Repository can assume this cloud identity via OIDC federation (Azure workload identity or AWS IAM role)",
       "is_traversable": true
+    },
+    {
+      "name": "GH_CanUseRunner",
+      "description": "[Actions] Repository can dispatch jobs to this self-hosted runner",
+      "is_traversable": false
+    },
+    {
+      "name": "GH_CanDispatchTo",
+      "description": "[Workflow] Job can dispatch to this self-hosted runner based on runs-on label matching and repository runner access",
+      "is_traversable": false
     },
     {
       "name": "GH_SyncedTo",


### PR DESCRIPTION
- collect organization self-hosted runner policy and store it on GH_Organization
- add GH_Organization.collected = true to mark successfully collected org nodes
- derive repository-level self-hosted runner enablement from org policy and store it on GH_Repository
- add self-hosted runner enumeration for both organization and repository scopes
- model runner groups as first-class nodes and capture their repository access boundaries
- add GH_OrgRunner and GH_RepoRunner node kinds for scoped runner objects
- retain GH_Runner as an internal generic kind used for shared matching logic
- add GH_CanUseRunner edges from repositories to runners to represent reachable runner access
- keep GH_CanUseRunner non-traversable for now as evidence rather than a proven attack path
- add workflow-to-runner matching based on runs-on labels and reachable runners
- add GH_CanDispatchTo edges from GH_WorkflowJob to matching self-hosted runners
- keep GH_CanDispatchTo non-traversable for now pending stronger exploitability evidence
- extend workflow parsing to normalize runs-on labels and resolve self-hosted dispatch candidates
- preserve reusable workflow parsing, job/step extraction, and existing workflow analysis outputs
- skip content download for dynamic/non-static workflow paths instead of attempting invalid fetches
- update schema and documentation for runner groups, org runners, repo runners, runner usage, workflow dispatch, and org/repo runner-related properties
- fix New-GitHubJwtSession to use InstallationId semantics while preserving AppId as a compatibility alias