### PR TITLE
Only pull workflows from default branch by default

### DIFF
--- a/githound.ps1
+++ b/githound.ps1
@@ -3707,11 +3707,19 @@ function Git-HoundWorkflow
     .PARAMETER ChunkSize
         Number of repos to process per chunk (default 50).
 
+    .PARAMETER WorkflowsDefaultBranchOnly
+        When set, only attempts to retrieve workflow file contents from the repository's default branch.
+        Skips the fallback that enumerates all branches looking for the workflow file. This significantly
+        reduces API calls for repositories with many branches.
+
     .OUTPUTS
         A PSObject containing arrays of nodes and edges representing the workflows and their relationships.
 
     .EXAMPLE
         $workflows = $repos | Git-HoundWorkflow -Session $Session
+
+    .EXAMPLE
+        $workflows = $repos | Git-HoundWorkflow -Session $Session -WorkflowsDefaultBranchOnly
     #>
     Param(
         [Parameter(Position = 0, Mandatory = $true)]
@@ -3732,7 +3740,11 @@ function Git-HoundWorkflow
 
         [Parameter()]
         [int]
-        $ChunkSize = 50
+        $ChunkSize = 50,
+
+        [Parameter()]
+        [switch]
+        $WorkflowsDefaultBranchOnly
     )
 
     begin
@@ -3819,6 +3831,7 @@ function Git-HoundWorkflow
                 $nodes = $using:chunkNodes
                 $edges = $using:chunkEdges
                 $Session = $using:Session
+                $defaultBranchOnly = $using:WorkflowsDefaultBranchOnly
                 $functionBundle = $using:GitHoundFunctionBundle
                 foreach($funcName in $functionBundle.Keys) {
                     Set-Item -Path "function:$funcName" -Value ([scriptblock]::Create($functionBundle[$funcName]))
@@ -3842,26 +3855,30 @@ function Git-HoundWorkflow
                                 $workflowBranch = $repo.properties.default_branch
                             }
                         } catch {
-                            # Workflow not on default branch — try other branches
-                            try {
-                                $branches = Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/branches" -ErrorAction Stop
-                                foreach ($branch in $branches) {
-                                    try {
-                                        $contentResponse = Invoke-GithubRestMethod -Session $Session -Path "$contentsBasePath`?ref=$($branch.name)" -ErrorAction Stop
-                                        if ($contentResponse.content) {
-                                            $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
-                                            $workflowBranch = $branch.name
-                                            break
+                            if ($defaultBranchOnly) {
+                                Write-Warning "Workflow $($repo.properties.full_name)/$($workflow.path) not found on default branch ($($repo.properties.default_branch)) — skipping (WorkflowsDefaultBranchOnly)"
+                            } else {
+                                # Workflow not on default branch — try other branches
+                                try {
+                                    $branches = Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/branches" -ErrorAction Stop
+                                    foreach ($branch in $branches) {
+                                        try {
+                                            $contentResponse = Invoke-GithubRestMethod -Session $Session -Path "$contentsBasePath`?ref=$($branch.name)" -ErrorAction Stop
+                                            if ($contentResponse.content) {
+                                                $workflowContent = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(($contentResponse.content -replace '\s','')))
+                                                $workflowBranch = $branch.name
+                                                break
+                                            }
+                                        } catch {
+                                            continue
                                         }
-                                    } catch {
-                                        continue
                                     }
+                                } catch {
+                                    Write-Warning "Could not list branches for $($repo.properties.full_name): $_"
                                 }
-                            } catch {
-                                Write-Warning "Could not list branches for $($repo.properties.full_name): $_"
-                            }
-                            if (-not $workflowContent) {
-                                Write-Warning "Could not download workflow contents for $($repo.properties.full_name)/$($workflow.path) on any branch"
+                                if (-not $workflowContent) {
+                                    Write-Warning "Could not download workflow contents for $($repo.properties.full_name)/$($workflow.path) on any branch"
+                                }
                             }
                         }
                     } else {
@@ -6066,6 +6083,11 @@ function Invoke-GitHound
     .PARAMETER CleanupIntermediates
         When set, deletes per-step output files after the final consolidated payload is written.
 
+    .PARAMETER WorkflowsDefaultBranchOnly
+        When set, only attempts to retrieve workflow file contents from the repository's default branch.
+        Skips the fallback that enumerates all branches looking for the workflow file. This significantly
+        reduces API calls for repositories with many branches. Passed through to Git-HoundWorkflow.
+
     .EXAMPLE
         Invoke-GitHound -Session $Session
 
@@ -6097,7 +6119,11 @@ function Invoke-GitHound
 
         [Parameter()]
         [switch]
-        $CollectAll
+        $CollectAll,
+
+        [Parameter()]
+        [switch]
+        $WorkflowsDefaultBranchOnly
     )
 
     $nodes = New-Object System.Collections.ArrayList
@@ -6234,7 +6260,12 @@ function Invoke-GitHound
             Write-Host "[+] Saved: githound_Workflow_$orgId.json"
         } else {
             Write-Host "[*] Enumerating Organization Workflows"
-            $workflows = $repos | Git-HoundWorkflow -Session $Session -CheckpointPath $CheckpointPath
+            $workflowParams = @{
+                Session        = $Session
+                CheckpointPath = $CheckpointPath
+            }
+            if ($WorkflowsDefaultBranchOnly) { $workflowParams['WorkflowsDefaultBranchOnly'] = $true }
+            $workflows = $repos | Git-HoundWorkflow @workflowParams
             Export-GitHoundStepOutput -StepResult $workflows -FilePath $stepFile
             Write-Host "[+] Saved: githound_Workflow_$orgId.json"
         }

--- a/githound.ps1
+++ b/githound.ps1
@@ -3707,10 +3707,10 @@ function Git-HoundWorkflow
     .PARAMETER ChunkSize
         Number of repos to process per chunk (default 50).
 
-    .PARAMETER WorkflowsDefaultBranchOnly
-        When set, only attempts to retrieve workflow file contents from the repository's default branch.
-        Skips the fallback that enumerates all branches looking for the workflow file. This significantly
-        reduces API calls for repositories with many branches.
+    .PARAMETER WorkflowsAllBranches
+        When set, falls back to enumerating all branches to find a workflow file if it is not present
+        on the repository's default branch. By default, only the default branch is checked. Enabling
+        this can significantly increase API calls and run time for repositories with many branches.
 
     .OUTPUTS
         A PSObject containing arrays of nodes and edges representing the workflows and their relationships.
@@ -3719,7 +3719,7 @@ function Git-HoundWorkflow
         $workflows = $repos | Git-HoundWorkflow -Session $Session
 
     .EXAMPLE
-        $workflows = $repos | Git-HoundWorkflow -Session $Session -WorkflowsDefaultBranchOnly
+        $workflows = $repos | Git-HoundWorkflow -Session $Session -WorkflowsAllBranches
     #>
     Param(
         [Parameter(Position = 0, Mandatory = $true)]
@@ -3744,7 +3744,7 @@ function Git-HoundWorkflow
 
         [Parameter()]
         [switch]
-        $WorkflowsDefaultBranchOnly
+        $WorkflowsAllBranches
     )
 
     begin
@@ -3831,7 +3831,7 @@ function Git-HoundWorkflow
                 $nodes = $using:chunkNodes
                 $edges = $using:chunkEdges
                 $Session = $using:Session
-                $defaultBranchOnly = $using:WorkflowsDefaultBranchOnly
+                $allBranches = $using:WorkflowsAllBranches
                 $functionBundle = $using:GitHoundFunctionBundle
                 foreach($funcName in $functionBundle.Keys) {
                     Set-Item -Path "function:$funcName" -Value ([scriptblock]::Create($functionBundle[$funcName]))
@@ -3855,9 +3855,7 @@ function Git-HoundWorkflow
                                 $workflowBranch = $repo.properties.default_branch
                             }
                         } catch {
-                            if ($defaultBranchOnly) {
-                                Write-Warning "Workflow $($repo.properties.full_name)/$($workflow.path) not found on default branch ($($repo.properties.default_branch)) — skipping (WorkflowsDefaultBranchOnly)"
-                            } else {
+                            if ($allBranches) {
                                 # Workflow not on default branch — try other branches
                                 try {
                                     $branches = Invoke-GithubRestMethod -Session $Session -Path "repos/$($repo.properties.full_name)/branches" -ErrorAction Stop
@@ -3879,6 +3877,8 @@ function Git-HoundWorkflow
                                 if (-not $workflowContent) {
                                     Write-Warning "Could not download workflow contents for $($repo.properties.full_name)/$($workflow.path) on any branch"
                                 }
+                            } else {
+                                Write-Warning "Workflow $($repo.properties.full_name)/$($workflow.path) not found on default branch ($($repo.properties.default_branch)) — skipping (use -WorkflowsAllBranches to search other branches)"
                             }
                         }
                     } else {
@@ -6083,10 +6083,11 @@ function Invoke-GitHound
     .PARAMETER CleanupIntermediates
         When set, deletes per-step output files after the final consolidated payload is written.
 
-    .PARAMETER WorkflowsDefaultBranchOnly
-        When set, only attempts to retrieve workflow file contents from the repository's default branch.
-        Skips the fallback that enumerates all branches looking for the workflow file. This significantly
-        reduces API calls for repositories with many branches. Passed through to Git-HoundWorkflow.
+    .PARAMETER WorkflowsAllBranches
+        When set, falls back to enumerating all branches to find a workflow file if it is not present
+        on the repository's default branch. By default, only the default branch is checked. Enabling
+        this can significantly increase API calls and run time for repositories with many branches.
+        Passed through to Git-HoundWorkflow.
 
     .EXAMPLE
         Invoke-GitHound -Session $Session
@@ -6123,7 +6124,7 @@ function Invoke-GitHound
 
         [Parameter()]
         [switch]
-        $WorkflowsDefaultBranchOnly
+        $WorkflowsAllBranches
     )
 
     $nodes = New-Object System.Collections.ArrayList
@@ -6264,7 +6265,7 @@ function Invoke-GitHound
                 Session        = $Session
                 CheckpointPath = $CheckpointPath
             }
-            if ($WorkflowsDefaultBranchOnly) { $workflowParams['WorkflowsDefaultBranchOnly'] = $true }
+            if ($WorkflowsAllBranches) { $workflowParams['WorkflowsAllBranches'] = $true }
             $workflows = $repos | Git-HoundWorkflow @workflowParams
             Export-GitHoundStepOutput -StepResult $workflows -FilePath $stepFile
             Write-Host "[+] Saved: githound_Workflow_$orgId.json"


### PR DESCRIPTION
GitHound will currently attempt to pull identified workflows from _all_ branches if they are not found on the default branch. For repositories with hundreds/thousands of branches this can result in repeating rate limit exhaustion. Even with the automated JWT refresh in https://github.com/SpecterOps/GitHound/pull/52 this can result in enumeration of an organization taking tens of hours or more.

~This pull request adds an additional, optional, argument of `-WorkflowsDefaultBranchOnly` that will only attempt to retrieve workflows from the default branch of a repository. While this is not exhaustive, and can result in misses for potentially problematic workflows on other branches, it permits the user to retrieve workflows without inflating the run time dramatically.~

This pull request, after discussion with @jaredcatkinson , changes the default behaviour of GitHound to only attempt to pull workflows from the default branch of the target repository unless a new `-WorkflowsAllBranches` argument is passed. While the default behaviour may result in workflows not being fully retrieved, in even moderately sized organizations and/or monorepo use cases this can reduce the run time from days to minutes.

Breaking changes:
  - Added `-WorkflowsAllBranches` — default behavior now skips branch enumeration
  - When a workflow isn't found on the default branch, it warns: `skipping (use -WorkflowsAllBranches to search other branches)`
  - When `-WorkflowsAllBranches` is passed, the old behavior is restored (enumerate all branches)
  - Both `Git-HoundWorkflow` and `Invoke-GitHound` updated with matching param/help/passthrough
