### PR TITLE
Add enterprise node foundation and document enterprise-aware sessions

### DIFF
--- a/Documentation/EdgeDescriptions/GH_Contains.md
+++ b/Documentation/EdgeDescriptions/GH_Contains.md
@@ -2,20 +2,22 @@
 
 ## Edge Schema
 
-- Source: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_Environment](../NodeDescriptions/GH_Environment.md)
-- Destination: [GH_User](../NodeDescriptions/GH_User.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
+- Source: [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md), [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_Environment](../NodeDescriptions/GH_Environment.md)
+- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_User](../NodeDescriptions/GH_User.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
 
 ## General Information
 
-The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. The organization serves as the top-level container for users, teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
+The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. At the top of that hierarchy, a `GH_Enterprise` contains its member organizations. An organization contains users, teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
 
 ```mermaid
 graph LR
+    ent("GH_Enterprise Example-Enterprise")
     node1("GH_Organization SpecterOps")
     node2("GH_User alice")
     node3("GH_Team engineering")
     node4("GH_Repository GitHound")
     node5("GH_RepoSecret DEPLOY_KEY")
+    ent -- GH_Contains --> node1
     node1 -- GH_Contains --> node2
     node1 -- GH_Contains --> node3
     node1 -- GH_Contains --> node4

--- a/Documentation/NodeDescriptions/GH_Enterprise.md
+++ b/Documentation/NodeDescriptions/GH_Enterprise.md
@@ -1,0 +1,39 @@
+# <img src="../Icons/gh_enterprise.png" width="50"/> GH_Enterprise
+
+Represents a GitHub Enterprise account. This is the structural parent of member organizations and the natural container for enterprise-wide settings and role relationships.
+
+Created by: `Git-HoundEnterprise`
+
+## Properties
+
+| Property Name         | Data Type | Description                                                                                      |
+| --------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| objectid              | string    | The GitHub GraphQL node ID of the enterprise, used as the unique graph identifier.              |
+| name                  | string    | The enterprise slug, used as the display name.                                                  |
+| node_id               | string    | The GitHub GraphQL node ID. Redundant with objectid.                                            |
+| collected             | boolean   | Marker property indicating that this enterprise node came from an actual GitHound collection.   |
+| environmentid         | string    | The enterprise node ID, used as the environment identifier for enterprise-scoped data.          |
+| environment_name      | string    | The enterprise slug, used as the environment name.                                              |
+| slug                  | string    | The enterprise slug (URL component).                                                            |
+| enterprise_name       | string    | The display name of the enterprise.                                                             |
+| description           | string    | The enterprise description.                                                                     |
+| location              | string    | The enterprise location.                                                                        |
+| url                   | string    | The primary GitHub URL for the enterprise.                                                      |
+| website_url           | string    | The enterprise website URL.                                                                     |
+| created_at            | string    | When the enterprise was created.                                                                |
+| updated_at            | string    | When the enterprise was last updated.                                                           |
+| billing_email         | string    | The enterprise billing contact email, when available.                                           |
+| security_contact_email| string    | The enterprise security contact email, when available.                                          |
+| viewer_is_admin       | boolean   | Whether the authenticated principal is an enterprise admin.                                     |
+
+Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
+    GH_Organization[fa:fa-building GH_Organization]
+
+    GH_Enterprise -.->|GH_Contains| GH_Organization
+```

--- a/Documentation/NodeDescriptions/GH_Organization.md
+++ b/Documentation/NodeDescriptions/GH_Organization.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_organization.png" width="50"/> GH_Organization
 
-Represents a GitHub organization. This is the root node of the graph and serves as the primary container for all other nodes. Organization-level settings such as default repository permissions, Actions configuration, and security features are captured as properties on this node.
+Represents a GitHub organization. In organization-scoped collections this is typically the top-level container for repositories, teams, users, and organization-scoped settings. In enterprise-aware collections, a `GH_Organization` may also appear as a child of `GH_Enterprise` via `GH_Contains`. Organization-level settings such as default repository permissions, Actions configuration, and security features are captured as properties on this node.
 
 Created by: `Git-HoundOrganization`
 
@@ -11,7 +11,7 @@ Created by: `Git-HoundOrganization`
 | objectid                                                     | string    | The GitHub `node_id` of the organization, used as the unique graph identifier.                                                                                                                |
 | id                                                           | integer   | The numeric GitHub ID of the organization.                                                                                                                                                    |
 | name                                                         | string    | The organization's login handle, used as the display name.                                                                                                                                    |
-| collected                                                    | boolean   | Marker property indicating that this organization node came from an actual GitHound collection rather than being synthesized or inferred.                                                   |
+| collected                                                    | boolean   | Marker property indicating whether this organization node came from a full organization collection. `false` may indicate a lightweight structural stub discovered from enterprise collection. |
 | login                                                        | string    | The organization's login handle (URL slug).                                                                                                                                                   |
 | node_id                                                      | string    | The GitHub GraphQL node ID. Redundant with objectid.                                                                                                                                          |
 | description                                                  | string    | The organization's description.                                                                                                                                                               |
@@ -74,6 +74,7 @@ Created by: `Git-HoundOrganization`
 
 ```mermaid
 flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
     GH_Repository[fa:fa-box-archive GH_Repository]
     GH_RunnerGroup[fa:fa-users-rectangle GH_RunnerGroup]
@@ -83,6 +84,7 @@ flowchart TD
     GH_OrgRole[fa:fa-user-tie GH_OrgRole]
 
 
+    GH_Enterprise -.->|GH_Contains| GH_Organization
     GH_Organization -.->|GH_Owns| GH_Repository
     GH_PersonalAccessToken[fa:fa-key GH_PersonalAccessToken]
     GH_PersonalAccessTokenRequest[fa:fa-key GH_PersonalAccessTokenRequest]

--- a/Documentation/Queries.md
+++ b/Documentation/Queries.md
@@ -186,6 +186,18 @@ LIMIT 1000
 
 This query can be imported into BloodHound from the [dangerous-branch-perms.json](../saved-queries/dangerous-branch-perms.json) file.
 
+## Enterprise to Organization Hierarchy
+
+Returns enterprises and the organizations they structurally contain.
+
+```cypher
+MATCH p=(enterprise:GH_Enterprise)-[:GH_Contains]->(org:GH_Organization)
+RETURN p
+LIMIT 1000
+```
+
+This query is helpful for validating enterprise discovery before running full organization collection.
+
 ## Organizations with default repository permission
 
 Returns organizations that have a default repository permission other than 'none'.

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -20,6 +20,7 @@
 | ![GH_AppInstallation](Icons/gh_appinstallation.png) | [GH_AppInstallation](NodeDescriptions/GH_AppInstallation.md) | GitHub App Installation |
 | ![GH_Branch](Icons/gh_branch.png) | [GH_Branch](NodeDescriptions/GH_Branch.md) | GitHub Branch |
 | ![GH_BranchProtectionRule](Icons/gh_branchprotectionrule.png) | [GH_BranchProtectionRule](NodeDescriptions/GH_BranchProtectionRule.md) | GitHub Branch Protection Rule |
+| ![GH_Enterprise](Icons/gh_enterprise.png) | [GH_Enterprise](NodeDescriptions/GH_Enterprise.md) | GitHub Enterprise |
 | ![GH_Environment](Icons/gh_environment.png) | [GH_Environment](NodeDescriptions/GH_Environment.md) | GitHub Environment |
 | ![GH_EnvironmentSecret](Icons/gh_environmentsecret.png) | [GH_EnvironmentSecret](NodeDescriptions/GH_EnvironmentSecret.md) | GitHub Environment Secret |
 | ![GH_EnvironmentVariable](Icons/gh_environmentvariable.png) | [GH_EnvironmentVariable](NodeDescriptions/GH_EnvironmentVariable.md) | GitHub Environment Variable |
@@ -70,7 +71,7 @@
 | [GH_CloseDiscussion](EdgeDescriptions/GH_CloseDiscussion.md) | ❌ | [Repository] Repo role can close discussions |
 | [GH_CloseIssue](EdgeDescriptions/GH_CloseIssue.md) | ❌ | [Repository] Repo role can close issues |
 | [GH_ClosePullRequest](EdgeDescriptions/GH_ClosePullRequest.md) | ❌ | [Repository] Repo role can close pull requests |
-| [GH_Contains](EdgeDescriptions/GH_Contains.md) | ❌ | Container relationship for organizational hierarchy (org contains secrets/variables, repo contains secrets/variables, environment contains secrets/variables) |
+| [GH_Contains](EdgeDescriptions/GH_Contains.md) | ❌ | Container relationship for organizational hierarchy (enterprise contains orgs, org contains secrets/variables, repo contains secrets/variables, environment contains secrets/variables) |
 | [GH_ConvertIssuesToDiscussions](EdgeDescriptions/GH_ConvertIssuesToDiscussions.md) | ❌ | [Repository] Repo role can convert issues to discussions |
 | [GH_CreateDiscussionCategory](EdgeDescriptions/GH_CreateDiscussionCategory.md) | ❌ | [Repository] Repo role can create discussion categories |
 | [GH_CreateRepository](EdgeDescriptions/GH_CreateRepository.md) | ❌ | [Organization] Org role can create repositories in the organization |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,49 @@ If collection is interrupted, resume from where you left off:
 Invoke-GitHound -Session $session -Resume
 ```
 
+## GitHub App Sessions
+
+GitHound supports both Personal Access Token sessions and GitHub App installation sessions.
+The existing organization-scoped GitHub App workflow is unchanged:
+
+```powershell
+. ./githound.ps1
+
+$session = New-GitHubJwtSession `
+  -OrganizationName "YourOrgName" `
+  -ClientId $clientId `
+  -PrivateKeyPath $privateKeyPath `
+  -InstallationId $installationId
+
+Invoke-GitHound -Session $session -CollectAll
+```
+
+The same function can also create enterprise-capable sessions:
+
+```powershell
+. ./githound.ps1
+
+$session = New-GitHubJwtSession `
+  -EnterpriseName "YourEnterpriseSlug" `
+  -ClientId $clientId `
+  -PrivateKeyPath $privateKeyPath `
+  -InstallationId $installationId `
+  -PersonalAccessToken $pat
+```
+
+Enterprise-capable sessions retain multiple auth contexts on the returned `GitHound.Session`:
+
+- `Headers`: the GitHub App installation token headers used for normal collection
+- `JwtHeaders`: GitHub App JWT headers used for app-level endpoints such as installation enumeration
+- `PatHeaders`: optional Personal Access Token headers for collection paths that require user-token auth
+
+To enumerate the installations that belong to the authenticated GitHub App:
+
+```powershell
+Get-GitHubAppInstallation -Session $session |
+  Select-Object TargetType, InstallationId, Login, Name, SuspendedAt
+```
+
 ## Workflow Analysis
 
 Workflow parsing is now built into `Invoke-GitHound` when you use `-CollectAll`. The collector
@@ -58,6 +101,19 @@ will:
 
 For resume/debugging purposes, the intermediate workflow-analysis checkpoint is written as
 `githound_WorkflowAnalysis_<orgId>.json`.
+
+## Enterprise Collection Foundation
+
+GitHound now includes a minimal enterprise collection foundation through `Git-HoundEnterprise`.
+That collector currently creates:
+
+- `GH_Enterprise`
+- lightweight `GH_Organization` stub nodes for member organizations
+- `GH_Contains` edges from the enterprise to its organizations
+
+These organization stubs are intentionally emitted with `collected = false`. They represent
+structural discovery from the enterprise context and are meant to be enriched later by normal
+organization collection.
 
 ## Schema
 

--- a/githound.ps1
+++ b/githound.ps1
@@ -347,6 +347,10 @@ function Invoke-GitHubGraphQL
         $Variables
     )
 
+    if (-not $Headers) {
+        $Headers = $Session.Headers
+    }
+
     $Body = @{
         query = $Query
         variables = $Variables
@@ -854,6 +858,153 @@ function ConvertTo-PascalCase
     $pascalCaseString = (Get-Culture).TextInfo.ToTitleCase($cleanedString).Replace(' ', '')
 
     return $pascalCaseString
+}
+
+function Git-HoundEnterprise
+{
+    <#
+    .SYNOPSIS
+        Fetches and processes a GitHub Enterprise node and its member organizations.
+
+    .DESCRIPTION
+        This function retrieves enterprise profile details and enumerates the organizations
+        that belong to the enterprise. It creates a GH_Enterprise node, minimal GH_Organization
+        stub nodes for discovered member organizations, and GH_Contains edges from the enterprise
+        to each organization.
+
+        The organization nodes emitted here are intentionally lightweight. They are meant to
+        establish the enterprise-to-organization structure and can later be enriched by the
+        normal organization collection path.
+
+    .PARAMETER Session
+        A GitHound.Session object with EnterpriseName set.
+
+    .EXAMPLE
+        $enterprise = Git-HoundEnterprise -Session $session
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterprise requires Session.EnterpriseName to be set."
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $enterpriseSlug = $Session.EnterpriseName
+    $enterprise = $null
+    $allOrganizations = New-Object System.Collections.ArrayList
+    $cursor = $null
+
+    Write-Host "[*] Git-HoundEnterprise: Collecting enterprise '$enterpriseSlug'"
+
+    do {
+        $query = @'
+query($slug: String!, $after: String) {
+  enterprise(slug: $slug) {
+    id
+    databaseId
+    name
+    slug
+    description
+    location
+    url
+    websiteUrl
+    createdAt
+    updatedAt
+    billingEmail
+    securityContactEmail
+    viewerIsAdmin
+    organizations(first: 100, after: $after) {
+      nodes {
+        id
+        login
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+'@
+
+        $variables = @{
+            slug = $enterpriseSlug
+            after = $cursor
+        }
+
+        $result = Invoke-GitHubGraphQL -Session $Session -Query $query -Variables $variables
+        $enterpriseResult = $result.data.enterprise
+
+        if (-not $enterpriseResult) {
+            throw "Enterprise '$enterpriseSlug' was not returned by the GraphQL API."
+        }
+
+        if (-not $enterprise) {
+            $enterprise = $enterpriseResult
+        }
+
+        foreach ($org in @($enterpriseResult.organizations.nodes)) {
+            $null = $allOrganizations.Add($org)
+        }
+
+        if ($enterpriseResult.organizations.pageInfo.hasNextPage) {
+            $cursor = $enterpriseResult.organizations.pageInfo.endCursor
+        } else {
+            $cursor = $null
+        }
+    } while ($cursor)
+
+    $enterpriseNodeId = $enterprise.id
+    $enterpriseProps = [pscustomobject]@{
+        name                   = Normalize-Null $enterprise.slug
+        node_id                = Normalize-Null $enterprise.id
+        collected              = $true
+        environmentid          = Normalize-Null $enterprise.id
+        environment_name       = Normalize-Null $enterprise.slug
+        slug                   = Normalize-Null $enterprise.slug
+        enterprise_name        = Normalize-Null $enterprise.name
+        description            = Normalize-Null $enterprise.description
+        location               = Normalize-Null $enterprise.location
+        url                    = Normalize-Null $enterprise.url
+        website_url            = Normalize-Null $enterprise.websiteUrl
+        created_at             = Normalize-Null $enterprise.createdAt
+        updated_at             = Normalize-Null $enterprise.updatedAt
+        billing_email          = Normalize-Null $enterprise.billingEmail
+        security_contact_email = Normalize-Null $enterprise.securityContactEmail
+        viewer_is_admin        = Normalize-Null $enterprise.viewerIsAdmin
+        query_organizations    = "MATCH p=(:GH_Enterprise {node_id:'$($enterprise.id)'})-[:GH_Contains]->(:GH_Organization) RETURN p"
+    }
+
+    $null = $nodes.Add((New-GitHoundNode -Id $enterpriseNodeId -Kind 'GH_Enterprise' -Properties $enterpriseProps))
+
+    foreach ($org in @($allOrganizations)) {
+        $orgProps = [pscustomobject]@{
+            name             = Normalize-Null $org.login
+            node_id          = Normalize-Null $org.id
+            collected        = $false
+            environmentid    = Normalize-Null $org.id
+            environment_name = Normalize-Null $org.login
+            login            = Normalize-Null $org.login
+            query_enterprise = "MATCH p=(:GH_Enterprise {node_id:'$($enterprise.id)'})-[:GH_Contains]->(:GH_Organization {node_id:'$($org.id)'}) RETURN p"
+        }
+
+        $null = $nodes.Add((New-GitHoundNode -Id $org.id -Kind 'GH_Organization' -Properties $orgProps))
+        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $enterpriseNodeId -EndId $org.id -Properties @{ traversable = $false }))
+    }
+
+    Write-Host "[+] Git-HoundEnterprise complete. 1 enterprise, $($allOrganizations.Count) organization stub(s), $($edges.Count) containment edge(s)."
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
 }
 
 function New-BHOGPropertyMatcher

--- a/schema.json
+++ b/schema.json
@@ -7,6 +7,14 @@
   },
   "node_kinds": [
     {
+      "name": "GH_Enterprise",
+      "display_name": "GitHub Enterprise",
+      "description": "A GitHub Enterprise account that contains member organizations and enterprise-wide settings",
+      "is_display_kind": true,
+      "icon": "globe",
+      "color": "#4A90D9"
+    },
+    {
       "name": "GH_Organization",
       "display_name": "GitHub Organization",
       "description": "A GitHub Organization—top-level container for repositories, teams, and settings",


### PR DESCRIPTION
- add Git-HoundEnterprise to collect a GH_Enterprise node and its member organizations
- create lightweight GH_Organization stub nodes for enterprise member organizations with collected=false
- add GH_Contains edges from GH_Enterprise to GH_Organization to model enterprise hierarchy
- add GH_Enterprise to schema.json and align its icon/color with the enterprise branch visual definition
- add GH_Enterprise node documentation and update GH_Organization docs to describe enterprise-parent relationships and stub organization semantics
- update GH_Contains and schema documentation to include enterprise-to-organization containment
- add README guidance for organization-scoped and enterprise-scoped New-GitHubJwtSession usage
- document session auth contexts including Headers, JwtHeaders, and PatHeaders
- document Get-GitHubAppInstallation usage for enumerating app installations
- add a query example for validating enterprise-to-organization hierarchy discovery
- fix Invoke-GitHubGraphQL to default to Session.Headers when explicit headers are not supplied so enterprise GraphQL collection uses authenticated requests