### PR TITLE
Add enterprise user collection and explicit membership edges

### DIFF
--- a/Documentation/EdgeDescriptions/GH_Contains.md
+++ b/Documentation/EdgeDescriptions/GH_Contains.md
@@ -3,23 +3,21 @@
 ## Edge Schema
 
 - Source: [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md), [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_Environment](../NodeDescriptions/GH_Environment.md)
-- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_User](../NodeDescriptions/GH_User.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
+- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
 
 ## General Information
 
-The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. At the top of that hierarchy, a `GH_Enterprise` contains its member organizations. An organization contains users, teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
+The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. At the top of that hierarchy, a `GH_Enterprise` contains its member organizations. An organization contains teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. Principal membership is modeled separately through [GH_HasMember](GH_HasMember.md) rather than `GH_Contains`. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
 
 ```mermaid
 graph LR
     ent("GH_Enterprise Example-Enterprise")
     node1("GH_Organization SpecterOps")
-    node2("GH_User alice")
-    node3("GH_Team engineering")
-    node4("GH_Repository GitHound")
-    node5("GH_RepoSecret DEPLOY_KEY")
+    node2("GH_Team engineering")
+    node3("GH_Repository GitHound")
+    node4("GH_RepoSecret DEPLOY_KEY")
     ent -- GH_Contains --> node1
     node1 -- GH_Contains --> node2
     node1 -- GH_Contains --> node3
-    node1 -- GH_Contains --> node4
-    node4 -- GH_Contains --> node5
+    node3 -- GH_Contains --> node4
 ```

--- a/Documentation/EdgeDescriptions/GH_HasMember.md
+++ b/Documentation/EdgeDescriptions/GH_HasMember.md
@@ -1,0 +1,19 @@
+# GH_HasMember
+
+## Edge Schema
+
+- Source: [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md), [GH_Organization](../NodeDescriptions/GH_Organization.md)
+- Destination: [GH_User](../NodeDescriptions/GH_User.md)
+
+## General Information
+
+The non-traversable [GH_HasMember](GH_HasMember.md) edge represents direct membership of a user in an enterprise or organization. This edge is structural and identity-oriented rather than privilege-bearing: it shows that the user belongs to the scope, but it does not by itself grant any permissions.
+
+At the enterprise level, this edge is created by `Git-HoundEnterpriseUser` from the GraphQL `enterprise.members` connection. Organization-level membership remains primarily modeled through default organization roles today, but `GH_HasMember` is the appropriate semantic edge when direct membership is collected as first-class data.
+
+```mermaid
+graph LR
+    ent("GH_Enterprise Example-Enterprise")
+    user("GH_User alice")
+    ent -- GH_HasMember --> user
+```

--- a/Documentation/NodeDescriptions/GH_Enterprise.md
+++ b/Documentation/NodeDescriptions/GH_Enterprise.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_enterprise.png" width="50"/> GH_Enterprise
 
-Represents a GitHub Enterprise account. This is the structural parent of member organizations and the natural container for enterprise-wide settings and role relationships.
+Represents a GitHub Enterprise account. This is the structural parent of member organizations and the natural container for enterprise-wide settings, role relationships, and enterprise membership.
 
 Created by: `Git-HoundEnterprise`
 
@@ -26,7 +26,7 @@ Created by: `Git-HoundEnterprise`
 | security_contact_email| string    | The enterprise security contact email, when available.                                          |
 | viewer_is_admin       | boolean   | Whether the authenticated principal is an enterprise admin.                                     |
 
-Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection.
+Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes.
 
 ## Diagram
 
@@ -34,6 +34,8 @@ Enterprise collection currently emits lightweight `GH_Organization` stub nodes f
 flowchart TD
     GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
+    GH_User[fa:fa-user GH_User]
 
     GH_Enterprise -.->|GH_Contains| GH_Organization
+    GH_Enterprise -.->|GH_HasMember| GH_User
 ```

--- a/Documentation/NodeDescriptions/GH_Organization.md
+++ b/Documentation/NodeDescriptions/GH_Organization.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_organization.png" width="50"/> GH_Organization
 
-Represents a GitHub organization. In organization-scoped collections this is typically the top-level container for repositories, teams, users, and organization-scoped settings. In enterprise-aware collections, a `GH_Organization` may also appear as a child of `GH_Enterprise` via `GH_Contains`. Organization-level settings such as default repository permissions, Actions configuration, and security features are captured as properties on this node.
+Represents a GitHub organization. In organization-scoped collections this is typically the top-level container for repositories, teams, roles, and organization-scoped settings. In enterprise-aware collections, a `GH_Organization` may also appear as a child of `GH_Enterprise` via `GH_Contains`. Organization-level settings such as default repository permissions, Actions configuration, and security features are captured as properties on this node. Organization membership itself is modeled through role assignments rather than `GH_Contains`.
 
 Created by: `Git-HoundOrganization`
 

--- a/Documentation/NodeDescriptions/GH_User.md
+++ b/Documentation/NodeDescriptions/GH_User.md
@@ -1,8 +1,8 @@
 # <img src="../Icons/gh_user.png" width="50"/> GH_User
 
-Represents a GitHub user who is a member of the organization. Users are associated with organization roles (Owner or Member) and can be assigned to repository roles and team roles.
+Represents a GitHub user who is a member of one or more GitHub organizations or enterprises. Users are associated with organization roles (Owner or Member), can be assigned to repository roles and team roles, and may also be linked directly to `GH_Enterprise` through `GH_HasMember`.
 
-Created by: `Git-HoundUser`
+Created by: `Git-HoundUser`, `Git-HoundEnterpriseUser`
 
 ## Properties
 
@@ -16,13 +16,14 @@ Created by: `Git-HoundUser`
 | full_name        | string    | The user's full name from their profile.                               |
 | id               | integer   | The numeric GitHub ID of the user.                                     |
 | node_id          | string    | The GitHub GraphQL node ID. Redundant with objectid.                   |
-| environment_name | string    | The name of the environment (GitHub organization) the user belongs to. |
-| environmentid    | string    | The node_id of the environment (GitHub organization).                  |
+| environment_name | string    | The name of the environment where the user was collected, such as a GitHub organization or enterprise. |
+| environmentid    | string    | The node_id of the environment where the user was collected. |
 
 ## Diagram
 
 ```mermaid
 flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_User[fa:fa-user GH_User]
     GH_OrgRole[fa:fa-user-tie GH_OrgRole]
     GH_RepoRole[fa:fa-user-tie GH_RepoRole]
@@ -42,6 +43,7 @@ flowchart TD
     GH_Repository[fa:fa-box-archive GH_Repository]
 
 
+    GH_Enterprise -.->|GH_HasMember| GH_User
     GH_User -->|GH_HasRole| GH_OrgRole
     GH_User -->|GH_HasRole| GH_TeamRole
     GH_User -->|GH_HasRole| GH_RepoRole

--- a/Documentation/Queries.md
+++ b/Documentation/Queries.md
@@ -198,6 +198,18 @@ LIMIT 1000
 
 This query is helpful for validating enterprise discovery before running full organization collection.
 
+## Enterprise Members
+
+Returns enterprises and the users that are direct members of those enterprises.
+
+```cypher
+MATCH p=(enterprise:GH_Enterprise)-[:GH_HasMember]->(user:GH_User)
+RETURN p
+LIMIT 1000
+```
+
+This query is useful for validating enterprise member discovery and Enterprise Managed Users handling.
+
 ## Organizations with default repository permission
 
 Returns organizations that have a default repository permission other than 'none'.

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -97,6 +97,7 @@
 | [GH_HasEnvironment](EdgeDescriptions/GH_HasEnvironment.md) | ❌ | Repository or branch has/can deploy to this environment |
 | [GH_HasExternalIdentity](EdgeDescriptions/GH_HasExternalIdentity.md) | ❌ | SAML identity provider has this external identity |
 | [GH_HasJob](EdgeDescriptions/GH_HasJob.md) | ✅ | Workflow contains this job |
+| [GH_HasMember](EdgeDescriptions/GH_HasMember.md) | ❌ | Enterprise or organization has this user as a member |
 | [GH_HasPersonalAccessToken](EdgeDescriptions/GH_HasPersonalAccessToken.md) | ❌ | User owns this personal access token that has been granted access to the organization |
 | [GH_HasPersonalAccessTokenRequest](EdgeDescriptions/GH_HasPersonalAccessTokenRequest.md) | ❌ | User has a pending personal access token request for the organization |
 | [GH_HasRole](EdgeDescriptions/GH_HasRole.md) | ✅ | User or team has a role assignment (org role, team role, or repo role) |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ That collector currently creates:
 - lightweight `GH_Organization` stub nodes for member organizations
 - `GH_Contains` edges from the enterprise to its organizations
 
+Enterprise user collection through `Git-HoundEnterpriseUser` adds:
+
+- `GH_User`
+- `GH_HasMember` edges from the enterprise to those users
+
 These organization stubs are intentionally emitted with `collected = false`. They represent
 structural discovery from the enterprise context and are meant to be enriched later by normal
 organization collection.

--- a/githound.ps1
+++ b/githound.ps1
@@ -1007,6 +1007,148 @@ query($slug: String!, $after: String) {
     }
 }
 
+function Git-HoundEnterpriseUser
+{
+    <#
+    .SYNOPSIS
+        Fetches and processes GitHub Users for an enterprise.
+
+    .DESCRIPTION
+        This function retrieves enterprise members using the GitHub GraphQL API `enterprise.members`
+        connection. It creates GH_User nodes that match the shape used by Git-HoundUser and emits
+        GH_HasMember edges linking the enterprise to each discovered user.
+
+        Enterprise members can be returned either as normal `User` objects or as
+        `EnterpriseUserAccount` objects in Enterprise Managed Users (EMU) environments. When an
+        `EnterpriseUserAccount` is returned, the nested `user` object is preferred when available
+        so that the GH_User node identity matches org-level collection. If the nested `user` object
+        is absent, the enterprise account fields are used as a fallback.
+
+    .PARAMETER Session
+        A GitHound.Session object with EnterpriseName set.
+
+    .PARAMETER Enterprise
+        A GH_Enterprise node object from Git-HoundEnterprise.
+
+    .EXAMPLE
+        $enterpriseUsers = Git-HoundEnterpriseUser -Session $session -Enterprise $enterprise.Nodes[0]
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $true)]
+        [PSObject]
+        $Enterprise
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterpriseUser requires Session.EnterpriseName to be set."
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $enterpriseSlug = $Session.EnterpriseName
+    $enterpriseNodeId = Normalize-Null $(if ($Enterprise.id) { $Enterprise.id } elseif ($Enterprise.properties.node_id) { $Enterprise.properties.node_id } else { $null })
+
+    if (-not $enterpriseNodeId) {
+        throw "Git-HoundEnterpriseUser requires a GH_Enterprise node object with an id or properties.node_id."
+    }
+
+    Write-Host "[*] Git-HoundEnterpriseUser: Collecting enterprise members for '$enterpriseSlug'"
+
+    $Query = @'
+query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null) {
+    enterprise(slug: $slug) {
+        members(first: $count, after: $after) {
+            edges {
+                node {
+                    ... on User {
+                        id
+                        databaseId
+                        login
+                        name
+                        email
+                        company
+                    }
+                    ... on EnterpriseUserAccount {
+                        id
+                        login
+                        name
+                        user {
+                            id
+                            databaseId
+                            login
+                            name
+                            email
+                            company
+                        }
+                    }
+                }
+            }
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+        }
+    }
+}
+'@
+
+    $Variables = @{
+        slug = $enterpriseSlug
+        count = 100
+        after = $null
+    }
+
+    do {
+        $result = Invoke-GitHubGraphQL -Session $Session -Query $Query -Variables $Variables
+
+        foreach ($edge in @($result.data.enterprise.members.edges)) {
+            $member = $edge.node
+            $user = if ($member.user) { $member.user } else { $member }
+
+            if (-not $user.id) {
+                Write-Warning "Git-HoundEnterpriseUser: Skipping member '$($member.login)' because no user id was returned."
+                continue
+            }
+
+            $properties = @{
+                name                         = Normalize-Null $user.login
+                node_id                      = Normalize-Null $user.id
+                environment_name             = Normalize-Null $enterpriseSlug
+                environmentid                = Normalize-Null $enterpriseNodeId
+                login                        = Normalize-Null $user.login
+                full_name                    = Normalize-Null $user.name
+                company                      = Normalize-Null $user.company
+                email                        = Normalize-Null $user.email
+                query_personal_access_tokens = "MATCH p=(:GH_User {node_id: '$($user.id)'})-[]->(token) WHERE token:GH_PersonalAccessToken OR token:GH_PersonalAccessTokenRequest RETURN p"
+                query_roles                  = "MATCH p=(t:GH_User {node_id:'$($user.id)'})-[:GH_HasRole|GH_HasBaseRole|GH_MemberOf*1..]->(:GH_Role) RETURN p"
+                query_teams                  = "MATCH p=(:GH_User {node_id:'$($user.id)'})-[:GH_HasRole]->(t:GH_TeamRole)-[:GH_MemberOf*1..4]->(:GH_Team) RETURN p"
+                query_repositories           = "MATCH p=(t:GH_User {node_id:'$($user.id)'})-[:GH_HasRole|GH_HasBaseRole|GH_MemberOf*1..]->(:GH_RepoRole)-[:GH_ReadRepoContents|GH_WriteRepoContents|GH_WriteRepoPullRequests|GH_ManageWebhooks|GH_ManageDeployKeys|GH_PushProtectedBranch|GH_DeleteAlertsCodeScanning|GH_ViewSecretScanningAlerts|GH_RunOrgMigration|GH_BypassBranchProtection|GH_EditRepoProtections]->(:GH_Repository) RETURN p"
+                query_branches               = "MATCH p=(:GH_User {node_id:'$($user.id)'})-[r]->(:GH_BranchProtectionRule)-[:GH_ProtectedBy]->(:GH_Branch) RETURN p"
+                query_enterprises            = "MATCH p=(:GH_Enterprise)-[:GH_HasMember]->(:GH_User {node_id:'$($user.id)'}) RETURN p"
+            }
+
+            $null = $nodes.Add((New-GitHoundNode -Id $user.id -Kind 'GH_User' -Properties $properties))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasMember' -StartId $enterpriseNodeId -EndId $user.id -Properties @{ traversable = $false }))
+        }
+
+        $Variables['after'] = $result.data.enterprise.members.pageInfo.endCursor
+    }
+    while ($result.data.enterprise.members.pageInfo.hasNextPage)
+
+    Write-Host "[+] Git-HoundEnterpriseUser complete. $($nodes.Count) nodes, $($edges.Count) edges."
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
+}
+
 function New-BHOGPropertyMatcher
 {
     Param(


### PR DESCRIPTION
- add Git-HoundEnterpriseUser to enumerate enterprise members from the GitHub GraphQL enterprise.members connection
- create GH_User nodes for enterprise members using the same identity shape as org-level user collection
- add GH_HasMember edges from GH_Enterprise to GH_User to model enterprise membership explicitly
- handle EnterpriseUserAccount / EMU responses by preferring the nested user object when available and falling back to enterprise account fields when necessary
- keep enterprise membership separate from organization role assignment so enterprise presence does not imply org-level access
- update GH_User documentation to reflect enterprise membership and enterprise collection context
- update GH_Enterprise documentation to include enterprise-to-user membership via GH_HasMember
- add GH_HasMember edge documentation and surface it in Documentation/Schema.md
- update GH_Contains documentation to clarify that users are principals modeled through GH_HasMember rather than contained resources
- add a query example for validating enterprise member discovery
- document enterprise user collection in the README alongside the existing enterprise foundation notes