### PR TITLE
Add enterprise SAML collection and improve IdP user matching

### DIFF
--- a/Documentation/EdgeDescriptions/GH_HasExternalIdentity.md
+++ b/Documentation/EdgeDescriptions/GH_HasExternalIdentity.md
@@ -7,7 +7,7 @@
 
 ## General Information
 
-The non-traversable [GH_HasExternalIdentity](GH_HasExternalIdentity.md) edge represents the relationship between a SAML identity provider and the external identities (SSO users) it manages. Created by `Git-HoundGraphQlSamlProvider`, this edge links each external identity to the SAML provider that authenticated it. External identities are a key component in cross-platform attack path analysis because they bridge the gap between corporate identity providers and GitHub user accounts via the [GH_MapsToUser](GH_MapsToUser.md) edge. Enumerating external identities reveals which corporate users have linked GitHub accounts and enables mapping from IdP compromise to GitHub access.
+The non-traversable [GH_HasExternalIdentity](GH_HasExternalIdentity.md) edge represents the relationship between a SAML identity provider and the external identities (SSO users) it manages. Created by `Git-HoundGraphQlSamlProvider` and `Git-HoundEnterpriseSamlProvider`, this edge links each external identity to the SAML provider that authenticated it. External identities are a key component in cross-platform attack path analysis because they bridge the gap between corporate identity providers and GitHub user accounts via the [GH_MapsToUser](GH_MapsToUser.md) edge. Enumerating external identities reveals which corporate users have linked GitHub accounts and enables mapping from IdP compromise to GitHub access.
 
 ```mermaid
 graph LR

--- a/Documentation/EdgeDescriptions/GH_HasSamlIdentityProvider.md
+++ b/Documentation/EdgeDescriptions/GH_HasSamlIdentityProvider.md
@@ -2,18 +2,20 @@
 
 ## Edge Schema
 
-- Source: [GH_Organization](../NodeDescriptions/GH_Organization.md)
+- Source: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md)
 - Destination: [GH_SamlIdentityProvider](../NodeDescriptions/GH_SamlIdentityProvider.md)
 
 ## General Information
 
-The non-traversable [GH_HasSamlIdentityProvider](GH_HasSamlIdentityProvider.md) edge represents the relationship between an organization and its SAML identity provider configuration. Created by `Git-HoundGraphQlSamlProvider`, this edge links an organization to the SAML SSO provider used for authentication and user provisioning. SAML identity providers are a critical security component because they establish the trust boundary between an external identity provider (such as Entra ID or Okta) and the GitHub organization. Understanding this relationship is essential for mapping cross-platform attack paths where compromise of the identity provider could lead to access within the GitHub organization.
+The non-traversable [GH_HasSamlIdentityProvider](GH_HasSamlIdentityProvider.md) edge represents the relationship between an organization or enterprise and its SAML identity provider configuration. Created by `Git-HoundGraphQlSamlProvider` and `Git-HoundEnterpriseSamlProvider`, this edge links the GitHub scope to the SAML SSO provider used for authentication and user provisioning. SAML identity providers are a critical security component because they establish the trust boundary between an external identity provider (such as Entra ID or Okta) and the GitHub environment. Understanding this relationship is essential for mapping cross-platform attack paths where compromise of the identity provider could lead to access within GitHub.
 
 ```mermaid
 graph LR
+    node0("GH_Enterprise Example-Enterprise")
     node1("GH_Organization SpecterOps")
     node2("GH_SamlIdentityProvider entra-id-sso")
     node3("GH_ExternalIdentity alice@specterops.io")
+    node0 -- GH_HasSamlIdentityProvider --> node2
     node1 -- GH_HasSamlIdentityProvider --> node2
     node2 -- GH_HasExternalIdentity --> node3
 ```

--- a/Documentation/NodeDescriptions/GH_ExternalIdentity.md
+++ b/Documentation/NodeDescriptions/GH_ExternalIdentity.md
@@ -1,8 +1,8 @@
 # <img src="../Icons/gh_externalidentity.png" width="50"/> GH_ExternalIdentity
 
-Represents an external identity from a SAML or SCIM identity provider that is linked to a GitHub user. External identities map corporate user accounts (from providers like Okta, Azure AD, etc.) to GitHub user accounts, enabling single sign-on authentication. Each external identity can have both SAML and SCIM identity attributes.
+Represents an external identity from a SAML or SCIM identity provider that is linked to a GitHub user. External identities map corporate user accounts (from providers like Okta, Azure AD, etc.) to GitHub user accounts, enabling single sign-on authentication. Each external identity can have both SAML and SCIM identity attributes and may be scoped to either an organization or an enterprise SAML provider.
 
-Created by: `Git-HoundGraphQlSamlProvider`
+Created by: `Git-HoundGraphQlSamlProvider`, `Git-HoundEnterpriseSamlProvider`
 
 ## Properties
 
@@ -12,8 +12,8 @@ Created by: `Git-HoundGraphQlSamlProvider`
 | node_id                   | string    | The GraphQL ID of the external identity.                 |
 | name                      | string    | Same as objectid.                                        |
 | guid                      | string    | The GUID of the external identity.                       |
-| environmentid             | string    | The GraphQL ID of the environment (GitHub organization). |
-| environment_name          | string    | The name of the environment (GitHub organization).       |
+| environmentid             | string    | The GraphQL ID of the environment where the identity was collected (GitHub organization or enterprise). |
+| environment_name          | string    | The name of the environment where the identity was collected (GitHub organization or enterprise). |
 | saml_identity_family_name | string    | The family name from the SAML identity.                  |
 | saml_identity_given_name  | string    | The given name from the SAML identity.                   |
 | saml_identity_name_id     | string    | The SAML NameID attribute.                               |

--- a/Documentation/NodeDescriptions/GH_SamlIdentityProvider.md
+++ b/Documentation/NodeDescriptions/GH_SamlIdentityProvider.md
@@ -1,8 +1,8 @@
 # <img src="../Icons/gh_samlidentityprovider.png" width="50"/> GH_SamlIdentityProvider
 
-Represents a SAML identity provider configured for the organization. This node captures the SAML SSO configuration details and serves as the parent container for external identity mappings. Through external identities, it enables linking GitHub users to their corporate identities in the identity provider.
+Represents a SAML identity provider configured for either an organization or an enterprise. This node captures the SAML SSO configuration details and serves as the parent container for external identity mappings. Through external identities, it enables linking GitHub users to their corporate identities in the identity provider.
 
-Created by: `Git-HoundGraphQlSamlProvider`
+Created by: `Git-HoundGraphQlSamlProvider`, `Git-HoundEnterpriseSamlProvider`
 
 ## Properties
 
@@ -11,8 +11,8 @@ Created by: `Git-HoundGraphQlSamlProvider`
 | objectid              | string    | The GraphQL ID of the SAML identity provider.              |
 | name                  | string    | Same as objectid.                                          |
 | node_id               | string    | Same as objectid.                                          |
-| environment_name      | string    | The name of the environment (GitHub organization).         |
-| environmentid         | string    | The GraphQL ID of the environment (GitHub organization).   |
+| environment_name      | string    | The name of the environment where the provider is configured (GitHub organization or enterprise). |
+| environmentid         | string    | The GraphQL ID of the environment where the provider is configured (GitHub organization or enterprise). |
 | foreign_environmentid | string    | The ID of the foreign environment linked to this provider. |
 | digest_method         | string    | The digest method used by the SAML provider.               |
 | idp_certificate       | string    | The identity provider's X.509 certificate.                 |
@@ -24,11 +24,13 @@ Created by: `Git-HoundGraphQlSamlProvider`
 
 ```mermaid
 flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
     GH_SamlIdentityProvider[fa:fa-id-badge GH_SamlIdentityProvider]
     GH_ExternalIdentity[fa:fa-arrows-left-right GH_ExternalIdentity]
 
 
+    GH_Enterprise -.->|GH_HasSamlIdentityProvider| GH_SamlIdentityProvider
     GH_Organization -.->|GH_HasSamlIdentityProvider| GH_SamlIdentityProvider
     GH_SamlIdentityProvider -.->|GH_HasExternalIdentity| GH_ExternalIdentity
 ```

--- a/Documentation/Queries.md
+++ b/Documentation/Queries.md
@@ -589,7 +589,7 @@ Finds SAML Identity Providers, their external identities, and mapped users.
 
 ```cypher
 MATCH p=(OIP:GH_SamlIdentityProvider)-[:GH_HasExternalIdentity]->(EI:GH_ExternalIdentity)
-MATCH p1=(OIP)<-[:GH_HasSamlIdentityProvider]-(:GH_Organization)
+MATCH p1=(OIP)<-[:GH_HasSamlIdentityProvider]-(:GH_Organization|GH_Enterprise)
 MATCH p2=(EI)-[:GH_MapsToUser]->()
 RETURN p,p1,p2
 LIMIT 1000

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -101,7 +101,7 @@
 | [GH_HasPersonalAccessToken](EdgeDescriptions/GH_HasPersonalAccessToken.md) | ❌ | User owns this personal access token that has been granted access to the organization |
 | [GH_HasPersonalAccessTokenRequest](EdgeDescriptions/GH_HasPersonalAccessTokenRequest.md) | ❌ | User has a pending personal access token request for the organization |
 | [GH_HasRole](EdgeDescriptions/GH_HasRole.md) | ✅ | User or team has a role assignment (org role, team role, or repo role) |
-| [GH_HasSamlIdentityProvider](EdgeDescriptions/GH_HasSamlIdentityProvider.md) | ❌ | Organization has this SAML identity provider configured |
+| [GH_HasSamlIdentityProvider](EdgeDescriptions/GH_HasSamlIdentityProvider.md) | ❌ | Organization or enterprise has this SAML identity provider configured |
 | [GH_HasSecret](EdgeDescriptions/GH_HasSecret.md) | ✅ | Repository or environment has access to this secret |
 | [GH_HasStep](EdgeDescriptions/GH_HasStep.md) | ✅ | Job contains this step |
 | [GH_HasVariable](EdgeDescriptions/GH_HasVariable.md) | ✅ | Repository has access to this variable (org-level or repo-level) |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ Enterprise user collection through `Git-HoundEnterpriseUser` adds:
 - `GH_User`
 - `GH_HasMember` edges from the enterprise to those users
 
+Enterprise SAML collection through `Git-HoundEnterpriseSamlProvider` adds:
+
+- `GH_SamlIdentityProvider`
+- `GH_ExternalIdentity`
+- `GH_HasSamlIdentityProvider` from the enterprise to the provider
+- the same identity-correlation edges used by the organization SAML collector
+
+This path requires a PAT-backed session because GitHub exposes enterprise SAML through
+`enterprise.ownerInfo`.
+
 These organization stubs are intentionally emitted with `collected = false`. They represent
 structural discovery from the enterprise context and are meant to be enriched later by normal
 organization collection.

--- a/githound.ps1
+++ b/githound.ps1
@@ -1149,6 +1149,220 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
     }
 }
 
+function Git-HoundEnterpriseSamlProvider
+{
+    <#
+    .SYNOPSIS
+        Retrieves the enterprise SAML identity provider and external identities.
+
+    .DESCRIPTION
+        This function queries the enterprise `ownerInfo.samlIdentityProvider` GraphQL path
+        to collect enterprise-scoped SAML configuration and external identity mappings.
+        It creates GH_SamlIdentityProvider and GH_ExternalIdentity nodes, links the
+        enterprise to the provider with GH_HasSamlIdentityProvider, and emits the same
+        identity-correlation edges used by the organization-scoped SAML collector.
+
+        This path requires a PAT-backed session because `enterprise.ownerInfo` is not
+        accessible through GitHub App installation tokens.
+
+    .PARAMETER Session
+        A GitHound.Session object with EnterpriseName and PatHeaders set.
+
+    .EXAMPLE
+        $saml = Git-HoundEnterpriseSamlProvider -Session $session
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterpriseSamlProvider requires Session.EnterpriseName to be set."
+    }
+
+    $patHeaders = Get-GitHoundAuthHeaders -Session $Session -AuthType PAT
+
+    $Query = @'
+query EnterpriseSAML($slug: String!, $count: Int = 100, $after: String = null) {
+    enterprise(slug: $slug) {
+        id
+        name
+        slug
+        ownerInfo {
+            samlIdentityProvider {
+                id
+                issuer
+                ssoUrl
+                digestMethod
+                signatureMethod
+                idpCertificate
+                externalIdentities(first: $count, after: $after) {
+                    totalCount
+                    nodes {
+                        guid
+                        id
+                        samlIdentity {
+                            familyName
+                            givenName
+                            nameId
+                            username
+                        }
+                        scimIdentity {
+                            username
+                            givenName
+                            familyName
+                            emails {
+                                value
+                                primary
+                                type
+                            }
+                        }
+                        user {
+                            id
+                            login
+                        }
+                    }
+                    pageInfo {
+                        endCursor
+                        hasNextPage
+                    }
+                }
+            }
+        }
+    }
+}
+'@
+
+    $Variables = @{
+        slug = $Session.EnterpriseName
+        count = 100
+        after = $null
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $firstPage = $true
+    $ForeignUserNodeKind = $null
+    $ForeignEnvironmentId = $null
+
+    Write-Host "[*] Git-HoundEnterpriseSamlProvider: Collecting enterprise SAML for '$($Session.EnterpriseName)'"
+
+    do {
+        $result = Invoke-GitHubGraphQL -Session $Session -Headers $patHeaders -Query $Query -Variables $Variables
+
+        $enterprise = $result.data.enterprise
+        $samlProvider = $enterprise.ownerInfo.samlIdentityProvider
+
+        if ($null -eq $samlProvider) {
+            Write-Host "[-] Git-HoundEnterpriseSamlProvider: No SAML identity provider found."
+            Write-Output ([PSCustomObject]@{ Nodes = $nodes; Edges = $edges })
+            return
+        }
+
+        if ($firstPage) {
+            $firstPage = $false
+
+            switch -Wildcard ($samlProvider.issuer) {
+                'https://auth.pingone.com/*' {
+                    $ForeignUserNodeKind = 'PingOneUser'
+                    $ForeignEnvironmentId = $samlProvider.issuer.Split('/')[3]
+                }
+                'https://sts.windows.net/*' {
+                    $ForeignUserNodeKind = 'AZUser'
+                    $ForeignEnvironmentId = $samlProvider.issuer.Split('/')[3]
+                }
+                'http://www.okta.com/*' {
+                    $ForeignUserNodeKind = 'Okta_User'
+                    $ForeignEnvironmentId = $samlProvider.ssoUrl.Split('/')[2]
+                }
+                default {
+                    Write-Warning "Git-HoundEnterpriseSamlProvider: Unknown IdP issuer: $($samlProvider.issuer)"
+                }
+            }
+
+            $providerProps = [pscustomobject]@{
+                name                   = Normalize-Null $samlProvider.id
+                node_id                = Normalize-Null $samlProvider.id
+                environment_name       = Normalize-Null $enterprise.slug
+                environmentid          = Normalize-Null $enterprise.id
+                foreign_environmentid  = Normalize-Null $ForeignEnvironmentId
+                digest_method          = Normalize-Null $samlProvider.digestMethod
+                idp_certificate        = Normalize-Null $samlProvider.idpCertificate
+                issuer                 = Normalize-Null $samlProvider.issuer
+                signature_method       = Normalize-Null $samlProvider.signatureMethod
+                sso_url                = Normalize-Null $samlProvider.ssoUrl
+                query_environments     = "MATCH p=(:GH_SamlIdentityProvider {objectid: '$($samlProvider.id.ToUpper())'})<-[:GH_HasSamlIdentityProvider]->(:GH_Enterprise) RETURN p"
+                query_external_identities = "MATCH p=(:GH_SamlIdentityProvider {objectid: '$($samlProvider.id.ToUpper())'})-[:GH_HasExternalIdentity]->() RETURN p"
+            }
+
+            $null = $nodes.Add((New-GitHoundNode -Id $samlProvider.id -Kind 'GH_SamlIdentityProvider' -Properties $providerProps))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasSamlIdentityProvider' -StartId $enterprise.id -EndId $samlProvider.id -Properties @{ traversable = $false }))
+        }
+
+        foreach ($identity in @($samlProvider.externalIdentities.nodes)) {
+            $EIprops = [pscustomobject]@{
+                node_id                   = Normalize-Null $identity.id
+                name                      = Normalize-Null $identity.guid
+                guid                      = Normalize-Null $identity.guid
+                environmentid             = Normalize-Null $enterprise.id
+                environment_name          = Normalize-Null $enterprise.slug
+                saml_identity_family_name = Normalize-Null $identity.samlIdentity.familyName
+                saml_identity_given_name  = Normalize-Null $identity.samlIdentity.givenName
+                saml_identity_name_id     = Normalize-Null $identity.samlIdentity.nameId
+                saml_identity_username    = Normalize-Null $identity.samlIdentity.username
+                scim_identity_family_name = Normalize-Null $identity.scimIdentity.familyName
+                scim_identity_given_name  = Normalize-Null $identity.scimIdentity.givenName
+                scim_identity_username    = Normalize-Null $identity.scimIdentity.username
+                github_username           = Normalize-Null $(if ($identity.user) { $identity.user.login } else { $null })
+                github_user_id            = Normalize-Null $(if ($identity.user) { $identity.user.id } else { $null })
+                query_mapped_users        = "MATCH p=(:GH_ExternalIdentity {objectid: '$($identity.id.ToUpper())'})-[:GH_MapsToUser]->() RETURN p"
+            }
+
+            $null = $nodes.Add((New-GitHoundNode -Id $identity.id -Kind 'GH_ExternalIdentity' -Properties $EIprops))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasExternalIdentity' -StartId $samlProvider.id -EndId $identity.id -Properties @{ traversable = $false }))
+
+            $foreignUsername = if ($identity.samlIdentity.username) { $identity.samlIdentity.username } elseif ($identity.scimIdentity.username) { $identity.scimIdentity.username } else { $null }
+            $foreignUserMatchers = Get-GitHoundForeignUserPropertyMatchers -ForeignUserNodeKind $ForeignUserNodeKind -Username $foreignUsername -ForeignEnvironmentId $ForeignEnvironmentId
+
+            if ($foreignUsername -and $ForeignUserNodeKind) {
+                if ($foreignUserMatchers) {
+                    $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MapsToUser' -StartId $identity.id -EndKind $ForeignUserNodeKind -EndPropertyMatchers $foreignUserMatchers -Properties @{ traversable = $false }))
+                }
+                else {
+                    $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MapsToUser' -StartId $identity.id -EndId $foreignUsername -EndKind $ForeignUserNodeKind -EndMatchBy 'name' -Properties @{ traversable = $false }))
+                }
+            }
+
+            if ($identity.user -ne $null -and $identity.user.id -ne $null) {
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MapsToUser' -StartId $identity.id -EndId $identity.user.id -Properties @{ traversable = $false }))
+
+                $matchUsername = if ($identity.samlIdentity.username) { $identity.samlIdentity.username } elseif ($identity.scimIdentity.username) { $identity.scimIdentity.username } else { $null }
+                if ($ForeignUserNodeKind -and $matchUsername) {
+                    if ($foreignUserMatchers) {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_SyncedTo' -StartKind $ForeignUserNodeKind -StartPropertyMatchers $foreignUserMatchers -EndId $identity.user.id -Properties @{ traversable = $true }))
+                    }
+                    else {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_SyncedTo' -StartId $matchUsername -StartKind $ForeignUserNodeKind -StartMatchBy 'name' -EndId $identity.user.id -Properties @{ traversable = $true }))
+                    }
+                }
+            }
+        }
+
+        $Variables['after'] = $samlProvider.externalIdentities.pageInfo.endCursor
+    }
+    while ($samlProvider.externalIdentities.pageInfo.hasNextPage)
+
+    Write-Host "[+] Git-HoundEnterpriseSamlProvider complete. $($nodes.Count) nodes, $($edges.Count) edges."
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
+}
+
 function New-BHOGPropertyMatcher
 {
     Param(
@@ -1164,6 +1378,52 @@ function New-BHOGPropertyMatcher
     )
 
     @{ key = $Key; operator = $Operator; value = $Value }
+}
+
+function Get-GitHoundForeignUserPropertyMatchers
+{
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$ForeignUserNodeKind,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Username,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ForeignEnvironmentId
+    )
+
+    if (-not $ForeignUserNodeKind -or -not $Username) {
+        return $null
+    }
+
+    switch ($ForeignUserNodeKind) {
+        'AZUser' {
+            $matchers = @(
+                (New-BHOGPropertyMatcher -Key 'userprincipalname' -Value $Username)
+            )
+
+            if ($ForeignEnvironmentId) {
+                $matchers += (New-BHOGPropertyMatcher -Key 'tenantid' -Value $ForeignEnvironmentId)
+            }
+
+            return $matchers
+        }
+        'Okta_User' {
+            $matchers = @(
+                (New-BHOGPropertyMatcher -Key 'login' -Value $Username)
+            )
+
+            if ($ForeignEnvironmentId) {
+                $matchers += (New-BHOGPropertyMatcher -Key 'oktaDomain' -Value $ForeignEnvironmentId)
+            }
+
+            return $matchers
+        }
+        default {
+            return $null
+        }
+    }
 }
 
 function Add-GitHoundSecretEdges
@@ -7443,13 +7703,19 @@ query SAML($login: String!, $count: Int = 100, $after: String = null) {
                 $null = $nodes.Add((New-GitHoundNode -Id $identity.id -Kind 'GH_ExternalIdentity' -Properties $EIprops))
                 $null = $edges.Add((New-GitHoundEdge -Kind GH_HasExternalIdentity -StartId $result.data.organization.samlIdentityProvider.id -EndId $identity.id -Properties @{traversable=$false}))
                 
-                if($identity.samlIdentity.username -ne $null)
+                $foreignUsername = if($identity.samlIdentity.username) { $identity.samlIdentity.username } elseif($identity.scimIdentity.username) { $identity.scimIdentity.username } else { $null }
+                $foreignUserMatchers = Get-GitHoundForeignUserPropertyMatchers -ForeignUserNodeKind $ForeignUserNodeKind -Username $foreignUsername -ForeignEnvironmentId $ForeignEnvironmentId
+
+                if($foreignUsername -and $ForeignUserNodeKind)
                 {
-                    $null = $edges.Add((New-GitHoundEdge -Kind GH_MapsToUser -StartId $identity.id -EndId $identity.samlIdentity.username -EndKind $ForeignUserNodeKind -EndMatchBy name -Properties @{traversable=$false}))
-                }
-                elseif($identity.scimIdentity.username -ne $null)
-                {
-                    $null = $edges.Add((New-GitHoundEdge -Kind GH_MapsToUser -StartId $identity.id -EndId $identity.scimIdentity.username -EndKind $ForeignUserNodeKind -EndMatchBy name -Properties @{traversable=$false}))
+                    if($foreignUserMatchers)
+                    {
+                        $null = $edges.Add((New-GitHoundEdge -Kind GH_MapsToUser -StartId $identity.id -EndKind $ForeignUserNodeKind -EndPropertyMatchers $foreignUserMatchers -Properties @{traversable=$false}))
+                    }
+                    else
+                    {
+                        $null = $edges.Add((New-GitHoundEdge -Kind GH_MapsToUser -StartId $identity.id -EndId $foreignUsername -EndKind $ForeignUserNodeKind -EndMatchBy name -Properties @{traversable=$false}))
+                    }
                 }
 
                 if($identity.user -ne $null -and $identity.user.id -ne $null)
@@ -7458,7 +7724,17 @@ query SAML($login: String!, $count: Int = 100, $after: String = null) {
                     
                     # Create GH_SyncedTo Edge from Foreign Identity to GH_User
                     # This might need to be something that happens during post-processing since we do not control whether the foreign user node already exists in the graph
-                    $null = $edges.Add((New-GitHoundEdge -Kind GH_SyncedTo -StartId $identity.samlIdentity.username -StartKind $ForeignUserNodeKind -StartMatchBy name -EndId $identity.user.id -Properties @{traversable=$true; composition="MATCH p=()<-[:GH_SyncedToEnvironment]-(:GH_SamlIdentityProvider)-[:GH_HasExternalIdentity]->(:GH_ExternalIdentity)-[:GH_MapsToUser]->(n) WHERE n.objectid = '$($identity.user.id.ToUpper())' OR n.name = '$($identity.samlIdentity.username.ToUpper())' RETURN p"}))
+                    if($ForeignUserNodeKind -and $foreignUsername)
+                    {
+                        if($foreignUserMatchers)
+                        {
+                            $null = $edges.Add((New-GitHoundEdge -Kind GH_SyncedTo -StartKind $ForeignUserNodeKind -StartPropertyMatchers $foreignUserMatchers -EndId $identity.user.id -Properties @{traversable=$true}))
+                        }
+                        else
+                        {
+                            $null = $edges.Add((New-GitHoundEdge -Kind GH_SyncedTo -StartId $foreignUsername -StartKind $ForeignUserNodeKind -StartMatchBy name -EndId $identity.user.id -Properties @{traversable=$true; composition="MATCH p=()<-[:GH_SyncedToEnvironment]-(:GH_SamlIdentityProvider)-[:GH_HasExternalIdentity]->(:GH_ExternalIdentity)-[:GH_MapsToUser]->(n) WHERE n.objectid = '$($identity.user.id.ToUpper())' OR n.name = '$($foreignUsername.ToUpper())' RETURN p"}))
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- add Git-HoundEnterpriseSamlProvider to collect enterprise-scoped SAML identity provider data from enterprise.ownerInfo.samlIdentityProvider
- create GH_SamlIdentityProvider and GH_ExternalIdentity nodes for enterprise SAML just as we do for organization SAML
- add GH_HasSamlIdentityProvider edges from GH_Enterprise to GH_SamlIdentityProvider
- add GH_HasExternalIdentity, GH_MapsToUser, and GH_SyncedTo edges for enterprise external identities
- require PAT-backed session auth for enterprise SAML collection and route the GraphQL call through Session.PatHeaders
- update SAML provider, external identity, schema, query, and README documentation to reflect enterprise-scoped SAML support
- add shared foreign-user property matcher logic for hybrid IdP mappings
- migrate Azure SAML identity matching from name-based matching to property-based matching using userprincipalname + tenantid
- migrate Okta SAML identity matching from name-based matching to property-based matching using login + oktaDomain
- apply the same Azure and Okta property-matching improvements to the existing organization SAML collector
- retain name-based fallback matching for unsupported IdP schemas such as PingOne until their OpenGraph property model is confirmed
- intentionally leave SCIM_Provisioned correlation out of the enterprise SAML implementation for now