### PR TITLE
Add enterprise team collection and assignment modeling

### DIFF
--- a/Documentation/EdgeDescriptions/GH_AssignedTo.md
+++ b/Documentation/EdgeDescriptions/GH_AssignedTo.md
@@ -1,0 +1,17 @@
+# GH_AssignedTo
+
+## Edge Schema
+
+- Source: [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md)
+- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md)
+
+## General Information
+
+The non-traversable [GH_AssignedTo](GH_AssignedTo.md) edge represents the structural assignment of an enterprise team to an organization. It is created from the enterprise team organization assignment API and indicates that GitHub projects the enterprise team into that organization. This edge is intentionally non-traversable because assignment alone does not grant privilege until the projected organization team is linked into repository or organization role paths.
+
+```mermaid
+graph LR
+    entTeam("GH_EnterpriseTeam Corp-Security")
+    org("GH_Organization example-org")
+    entTeam -- GH_AssignedTo --> org
+```

--- a/Documentation/EdgeDescriptions/GH_Contains.md
+++ b/Documentation/EdgeDescriptions/GH_Contains.md
@@ -3,20 +3,22 @@
 ## Edge Schema
 
 - Source: [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md), [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_Environment](../NodeDescriptions/GH_Environment.md)
-- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
+- Destination: [GH_Organization](../NodeDescriptions/GH_Organization.md), [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_Repository](../NodeDescriptions/GH_Repository.md), [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_OrgSecret](../NodeDescriptions/GH_OrgSecret.md), [GH_AppInstallation](../NodeDescriptions/GH_AppInstallation.md), [GH_PersonalAccessToken](../NodeDescriptions/GH_PersonalAccessToken.md), [GH_PersonalAccessTokenRequest](../NodeDescriptions/GH_PersonalAccessTokenRequest.md), [GH_RepoSecret](../NodeDescriptions/GH_RepoSecret.md), [GH_EnvironmentSecret](../NodeDescriptions/GH_EnvironmentSecret.md), [GH_SecretScanningAlert](../NodeDescriptions/GH_SecretScanningAlert.md)
 
 ## General Information
 
-The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. At the top of that hierarchy, a `GH_Enterprise` contains its member organizations. An organization contains teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. Principal membership is modeled separately through [GH_HasMember](GH_HasMember.md) rather than `GH_Contains`. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
+The non-traversable [GH_Contains](GH_Contains.md) edge represents structural containment within the GitHub resource hierarchy. At the top of that hierarchy, a `GH_Enterprise` contains its member organizations and enterprise teams. An organization contains teams, repositories, roles, secrets, app installations, and personal access tokens. Repositories contain their own repo-level secrets, and environments contain environment-scoped secrets. Principal membership is modeled separately through [GH_HasMember](GH_HasMember.md), and enterprise-team deployment into organizations is modeled with [GH_AssignedTo](GH_AssignedTo.md) rather than `GH_Contains`. This edge is created by the collector to establish the organizational hierarchy of GitHub resources and is not traversable because containment alone does not imply privilege escalation.
 
 ```mermaid
 graph LR
     ent("GH_Enterprise Example-Enterprise")
     node1("GH_Organization SpecterOps")
+    entTeam("GH_EnterpriseTeam Corp-Security")
     node2("GH_Team engineering")
     node3("GH_Repository GitHound")
     node4("GH_RepoSecret DEPLOY_KEY")
     ent -- GH_Contains --> node1
+    ent -- GH_Contains --> entTeam
     node1 -- GH_Contains --> node2
     node1 -- GH_Contains --> node3
     node3 -- GH_Contains --> node4

--- a/Documentation/EdgeDescriptions/GH_MemberOf.md
+++ b/Documentation/EdgeDescriptions/GH_MemberOf.md
@@ -2,20 +2,24 @@
 
 ## Edge Schema
 
-- Source: [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_Team](../NodeDescriptions/GH_Team.md)
-- Destination: [GH_Team](../NodeDescriptions/GH_Team.md)
+- Source: [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md)
+- Destination: [GH_Team](../NodeDescriptions/GH_Team.md), [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md)
 
 ## General Information
 
-The traversable [GH_MemberOf](GH_MemberOf.md) edge represents team membership, linking a team role to its parent team or a child team to a parent team in nested team hierarchies. It is created by `Git-HoundTeam` during team enumeration. This edge is traversable because team membership extends access transitively -- a user who holds a role in a child team inherits the repository permissions of all ancestor teams in the nesting hierarchy, making it a key component of attack path analysis.
+The traversable [GH_MemberOf](GH_MemberOf.md) edge represents team membership, linking a team role to its parent team or a child team to a parent team in nested team hierarchies. At the enterprise layer it also links the synthetic members role to a `GH_EnterpriseTeam`, and links an enterprise team to its projected organization `GH_Team`. It is created by `Git-HoundTeam` and `Git-HoundEnterpriseTeam`. This edge is traversable because team membership extends access transitively -- a user who holds a role in a child team or enterprise team inherits the repository permissions of all ancestor teams in the hierarchy, making it a key component of attack path analysis.
 
 ```mermaid
 graph LR
     teamRole1("GH_TeamRole security-team\\maintainer")
     teamRole2("GH_TeamRole appsec-team\\member")
+    entTeamRole("GH_TeamRole corp-security\\members")
     childTeam("GH_Team appsec-team")
     parentTeam("GH_Team security-team")
+    entTeam("GH_EnterpriseTeam Corp-Security")
     teamRole1 -- GH_MemberOf --> parentTeam
     teamRole2 -- GH_MemberOf --> childTeam
     childTeam -- GH_MemberOf --> parentTeam
+    entTeamRole -- GH_MemberOf --> entTeam
+    entTeam -- GH_MemberOf --> parentTeam
 ```

--- a/Documentation/NodeDescriptions/GH_Enterprise.md
+++ b/Documentation/NodeDescriptions/GH_Enterprise.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_enterprise.png" width="50"/> GH_Enterprise
 
-Represents a GitHub Enterprise account. This is the structural parent of member organizations and the natural container for enterprise-wide settings, role relationships, and enterprise membership.
+Represents a GitHub Enterprise account. This is the structural parent of member organizations, enterprise teams, and the natural container for enterprise-wide settings, role relationships, and enterprise membership.
 
 Created by: `Git-HoundEnterprise`
 
@@ -26,7 +26,7 @@ Created by: `Git-HoundEnterprise`
 | security_contact_email| string    | The enterprise security contact email, when available.                                          |
 | viewer_is_admin       | boolean   | Whether the authenticated principal is an enterprise admin.                                     |
 
-Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes.
+Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes. Enterprise team collection adds `GH_EnterpriseTeam` nodes, links them with `GH_Contains`, and models organization assignment separately with `GH_AssignedTo`.
 
 ## Diagram
 
@@ -34,8 +34,10 @@ Enterprise collection currently emits lightweight `GH_Organization` stub nodes f
 flowchart TD
     GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
+    GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
     GH_User[fa:fa-user GH_User]
 
     GH_Enterprise -.->|GH_Contains| GH_Organization
+    GH_Enterprise -.->|GH_Contains| GH_EnterpriseTeam
     GH_Enterprise -.->|GH_HasMember| GH_User
 ```

--- a/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
+++ b/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
@@ -1,0 +1,42 @@
+# <img src="../Icons/gh_enterpriseteam.png" width="50"/> GH_EnterpriseTeam
+
+Represents a GitHub enterprise-level team. Enterprise teams are assigned into organizations from the enterprise layer and can map to organization-scoped `ent:` teams that then carry repository permissions.
+
+Created by: `Git-HoundEnterpriseTeam`
+
+## Properties
+
+| Property Name          | Data Type | Description |
+| ---------------------- | --------- | ----------- |
+| objectid               | string    | A synthetic enterprise-scoped identifier for the enterprise team. |
+| name                   | string    | The display name of the enterprise team. |
+| node_id                | string    | The enterprise team graph identifier. Redundant with objectid. |
+| github_team_id         | string    | The raw enterprise team id returned by the GitHub enterprise team API. |
+| environment_name       | string    | The enterprise slug. |
+| environmentid          | string    | The enterprise node id. |
+| enterpriseid           | string    | The enterprise node id, repeated explicitly for enterprise-scoped matching. |
+| slug                   | string    | The enterprise team slug. |
+| projected_slug         | string    | The projected organization team slug, typically using the `ent:` prefix. |
+| description            | string    | The team description. |
+| created_at             | string    | When the enterprise team was created. |
+| updated_at             | string    | When the enterprise team was last updated. |
+
+Enterprise team membership is represented through a synthetic `GH_TeamRole` node (`members`) linked with `GH_MemberOf`. Organization assignment is represented with `GH_AssignedTo`, and the enterprise team is linked to org-visible `ent:` teams with a property-matched `GH_MemberOf` edge once those organization teams exist in the graph.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
+    GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
+    GH_Organization[fa:fa-building GH_Organization]
+    GH_Team[fa:fa-user-group GH_Team]
+    GH_TeamRole[fa:fa-user-tie GH_TeamRole]
+    GH_User[fa:fa-user GH_User]
+
+    GH_Enterprise -.->|GH_Contains| GH_EnterpriseTeam
+    GH_EnterpriseTeam -.->|GH_AssignedTo| GH_Organization
+    GH_TeamRole -->|GH_MemberOf| GH_EnterpriseTeam
+    GH_EnterpriseTeam -->|GH_MemberOf| GH_Team
+    GH_User -->|GH_HasRole| GH_TeamRole
+```

--- a/Documentation/NodeDescriptions/GH_Team.md
+++ b/Documentation/NodeDescriptions/GH_Team.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_team.png" width="50"/> GH_Team
 
-Represents a GitHub team within the organization. Teams can have parent-child relationships, contain members with different roles (Member, Maintainer), and be assigned to repository roles.
+Represents a GitHub team within the organization. Teams can have parent-child relationships, contain members with different roles (Member, Maintainer), and be assigned to repository roles. Some teams are enterprise-projected `ent:` teams, which are linked back to `GH_EnterpriseTeam`.
 
 Created by: `Git-HoundTeam`
 
@@ -8,13 +8,14 @@ Created by: `Git-HoundTeam`
 
 | Property Name    | Data Type | Description                                                               |
 | ---------------- | --------- | ------------------------------------------------------------------------- |
-| objectid         | string    | The GitHub GraphQL `id` of the team, used as the unique graph identifier. |
+| objectid         | string    | The GitHub team identifier used as the unique graph identifier. |
 | name             | string    | The team's display name, derived from the slug property.                  |
-| id               | string    | The GraphQL ID of the team.                                               |
-| node_id          | string    | The GitHub node ID. Redundant with objectid.                              |
+| github_team_id   | string    | The raw GitHub team id when known.                                        |
+| node_id          | string    | The GitHub team identifier. Redundant with objectid.                      |
 | slug             | string    | The team's URL-safe slug identifier.                                      |
 | description      | string    | The team's description.                                                   |
 | privacy          | string    | The team's privacy level (e.g., `visible`, `secret`).                     |
+| type             | string    | The team type. Enterprise-projected teams use `enterprise`.               |
 | permission       | string    | The team's default permission on repositories.                            |
 | environment_name | string    | The name of the environment (GitHub organization).                        |
 | environmentid    | string    | The node_id of the environment (GitHub organization).                     |
@@ -33,6 +34,7 @@ flowchart TD
 
 
     GH_Team -->|GH_MemberOf| GH_Team
+    GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
     GH_Team -->|GH_HasRole| GH_OrgRole
     GH_Team -->|GH_HasRole| GH_RepoRole
     GH_Team -.->|GH_BypassPullRequestAllowances| GH_BranchProtectionRule
@@ -41,4 +43,5 @@ flowchart TD
     GH_Team -->|GH_CanCreateBranch| GH_Repository
     GH_TeamRole -->|GH_MemberOf| GH_Team
     GH_TeamRole -->|GH_AddMember| GH_Team
+    GH_EnterpriseTeam -->|GH_MemberOf| GH_Team
 ```

--- a/Documentation/Queries.md
+++ b/Documentation/Queries.md
@@ -210,6 +210,18 @@ LIMIT 1000
 
 This query is useful for validating enterprise member discovery and Enterprise Managed Users handling.
 
+### Enterprise Team Assignments and Projections
+
+Returns enterprise teams, the organizations they are assigned to, and any projected `ent:` organization teams linked back to them.
+
+```cypher
+MATCH p=(entTeam:GH_EnterpriseTeam)-[:GH_AssignedTo]->(org:GH_Organization)
+OPTIONAL MATCH p2=(entTeam)-[:GH_MemberOf]->(team:GH_Team)
+RETURN p, p2
+```
+
+This query is useful for validating enterprise team collection and confirming that projected organization teams were linked back to their enterprise teams.
+
 ## Organizations with default repository permission
 
 Returns organizations that have a default repository permission other than 'none'.

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -21,6 +21,7 @@
 | ![GH_Branch](Icons/gh_branch.png) | [GH_Branch](NodeDescriptions/GH_Branch.md) | GitHub Branch |
 | ![GH_BranchProtectionRule](Icons/gh_branchprotectionrule.png) | [GH_BranchProtectionRule](NodeDescriptions/GH_BranchProtectionRule.md) | GitHub Branch Protection Rule |
 | ![GH_Enterprise](Icons/gh_enterprise.png) | [GH_Enterprise](NodeDescriptions/GH_Enterprise.md) | GitHub Enterprise |
+| ![GH_EnterpriseTeam](Icons/gh_enterpriseteam.png) | [GH_EnterpriseTeam](NodeDescriptions/GH_EnterpriseTeam.md) | GitHub Enterprise Team |
 | ![GH_Environment](Icons/gh_environment.png) | [GH_Environment](NodeDescriptions/GH_Environment.md) | GitHub Environment |
 | ![GH_EnvironmentSecret](Icons/gh_environmentsecret.png) | [GH_EnvironmentSecret](NodeDescriptions/GH_EnvironmentSecret.md) | GitHub Environment Secret |
 | ![GH_EnvironmentVariable](Icons/gh_environmentvariable.png) | [GH_EnvironmentVariable](NodeDescriptions/GH_EnvironmentVariable.md) | GitHub Environment Variable |
@@ -52,6 +53,7 @@
 | Relationship Kind | Traversable | Description |
 |-------------------|:-----------:|-------------|
 | [GH_AddAssignee](EdgeDescriptions/GH_AddAssignee.md) | ❌ | [Repository] Repo role can assign users to issues and pull requests |
+| [GH_AssignedTo](EdgeDescriptions/GH_AssignedTo.md) | ❌ | Structural assignment relationship showing that an enterprise team is assigned to an organization |
 | [GH_AddCollaborator](EdgeDescriptions/GH_AddCollaborator.md) | ❌ | [Organization] Org role can add outside collaborators |
 | [GH_AddLabel](EdgeDescriptions/GH_AddLabel.md) | ❌ | [Repository] Repo role can add labels to issues and pull requests |
 | [GH_AddMember](EdgeDescriptions/GH_AddMember.md) | ✅ | Team role can add members to the team (maintainer privilege) |
@@ -71,7 +73,7 @@
 | [GH_CloseDiscussion](EdgeDescriptions/GH_CloseDiscussion.md) | ❌ | [Repository] Repo role can close discussions |
 | [GH_CloseIssue](EdgeDescriptions/GH_CloseIssue.md) | ❌ | [Repository] Repo role can close issues |
 | [GH_ClosePullRequest](EdgeDescriptions/GH_ClosePullRequest.md) | ❌ | [Repository] Repo role can close pull requests |
-| [GH_Contains](EdgeDescriptions/GH_Contains.md) | ❌ | Container relationship for organizational hierarchy (enterprise contains orgs, org contains secrets/variables, repo contains secrets/variables, environment contains secrets/variables) |
+| [GH_Contains](EdgeDescriptions/GH_Contains.md) | ❌ | Container relationship for organizational hierarchy (enterprise contains orgs and enterprise teams, org contains secrets/variables, repo contains secrets/variables, environment contains secrets/variables) |
 | [GH_ConvertIssuesToDiscussions](EdgeDescriptions/GH_ConvertIssuesToDiscussions.md) | ❌ | [Repository] Repo role can convert issues to discussions |
 | [GH_CreateDiscussionCategory](EdgeDescriptions/GH_CreateDiscussionCategory.md) | ❌ | [Repository] Repo role can create discussion categories |
 | [GH_CreateRepository](EdgeDescriptions/GH_CreateRepository.md) | ❌ | [Organization] Org role can create repositories in the organization |
@@ -122,7 +124,7 @@
 | [GH_ManageWebhooks](EdgeDescriptions/GH_ManageWebhooks.md) | ❌ | [Repository] Repo role can manage repository webhooks |
 | [GH_MapsToUser](EdgeDescriptions/GH_MapsToUser.md) | ❌ | External identity maps to a GitHub user or identity provider user |
 | [GH_MarkAsDuplicate](EdgeDescriptions/GH_MarkAsDuplicate.md) | ❌ | [Repository] Repo role can mark issues or pull requests as duplicates |
-| [GH_MemberOf](EdgeDescriptions/GH_MemberOf.md) | ✅ | Team role is a member of a team, or team is a nested member of a parent team |
+| [GH_MemberOf](EdgeDescriptions/GH_MemberOf.md) | ✅ | Team role is a member of a team or enterprise team, or team is a nested/projection member of another team |
 | [GH_OrgBypassCodeScanningDismissalRequests](EdgeDescriptions/GH_OrgBypassCodeScanningDismissalRequests.md) | ❌ | [Organization] Org role can bypass code scanning dismissal requests |
 | [GH_OrgBypassSecretScanningClosureRequests](EdgeDescriptions/GH_OrgBypassSecretScanningClosureRequests.md) | ❌ | [Organization] Org role can bypass secret scanning closure requests |
 | [GH_OrgReviewAndManageSecretScanningBypassRequests](EdgeDescriptions/GH_OrgReviewAndManageSecretScanningBypassRequests.md) | ❌ | [Organization] Org role can review and manage secret scanning bypass requests |

--- a/README.md
+++ b/README.md
@@ -126,9 +126,16 @@ Enterprise SAML collection through `Git-HoundEnterpriseSamlProvider` adds:
 This path requires a PAT-backed session because GitHub exposes enterprise SAML through
 `enterprise.ownerInfo`.
 
-These organization stubs are intentionally emitted with `collected = false`. They represent
-structural discovery from the enterprise context and are meant to be enriched later by normal
-organization collection.
+Enterprise team collection through `Git-HoundEnterpriseTeam` adds:
+
+- `GH_EnterpriseTeam`
+- `GH_AssignedTo` edges from enterprise teams to assigned organizations
+- `GH_MemberOf` edges from enterprise teams to org-visible `ent:` `GH_Team` nodes using property matching
+- enterprise-team `members` roles and `GH_HasRole` edges from users to those roles
+
+The `GH_Organization` stubs emitted by enterprise collection are intentionally marked
+`collected = false`. They represent structural discovery from the enterprise context and are
+meant to be enriched later by normal organization collection.
 
 ## Schema
 

--- a/githound.ps1
+++ b/githound.ps1
@@ -732,6 +732,55 @@ function Normalize-Null
     
 }
 
+function Get-GitHoundEnterpriseTeamNodeId
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EnterpriseId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TeamId
+    )
+
+    "GH_EnterpriseTeam_${EnterpriseId}_${TeamId}"
+}
+
+function Get-GitHoundOrganizationTeamNodeId
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TeamNodeId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TeamSlug
+    )
+
+    return $TeamNodeId
+}
+
+function Get-GitHoundOrganizationTeamPropertyMatchers
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TeamSlug
+    )
+
+    if ($TeamSlug -notlike 'ent:*') {
+        return $null
+    }
+
+    @(
+        (New-BHOGPropertyMatcher -Key 'environmentid' -Value $OrganizationId),
+        (New-BHOGPropertyMatcher -Key 'slug' -Value $TeamSlug)
+    )
+}
+
 function Import-GitHoundStepOutput
 {
     <#
@@ -1142,6 +1191,125 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
     while ($result.data.enterprise.members.pageInfo.hasNextPage)
 
     Write-Host "[+] Git-HoundEnterpriseUser complete. $($nodes.Count) nodes, $($edges.Count) edges."
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
+}
+
+function Git-HoundEnterpriseTeam
+{
+    <#
+    .SYNOPSIS
+        Retrieves enterprise-level teams for a GitHub enterprise.
+
+    .DESCRIPTION
+        This function enumerates enterprise teams from the enterprise REST API and models
+        their structural relationship to assigned organizations. For each enterprise team,
+        it creates a GH_EnterpriseTeam node, a members GH_TeamRole, GH_HasRole edges from
+        enterprise members to that role, and GH_AssignedTo edges to organizations returned
+        by the enterprise team organization assignment API.
+
+        Because GitHub projects assigned enterprise teams into organizations using the
+        `ent:` slug prefix, this function also emits GH_MemberOf edges that property-match
+        those organization-scoped teams by organization and slug once they exist in the graph.
+
+    .PARAMETER Session
+        A GitHound.Session object with EnterpriseName set.
+
+    .PARAMETER Enterprise
+        A GH_Enterprise node object from Git-HoundEnterprise.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $true)]
+        [PSObject]
+        $Enterprise
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterpriseTeam requires Session.EnterpriseName to be set."
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $enterpriseSlug = $Session.EnterpriseName
+    $enterpriseNodeId = Normalize-Null $(if ($Enterprise.id) { $Enterprise.id } elseif ($Enterprise.properties.node_id) { $Enterprise.properties.node_id } else { $null })
+
+    if (-not $enterpriseNodeId) {
+        throw "Git-HoundEnterpriseTeam requires a GH_Enterprise node object with an id or properties.node_id."
+    }
+
+    Write-Host "[*] Git-HoundEnterpriseTeam: Collecting enterprise teams for '$enterpriseSlug'"
+
+    $teams = @(Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/teams")
+
+    foreach ($team in $teams) {
+        $enterpriseTeamId = Get-GitHoundEnterpriseTeamNodeId -EnterpriseId $enterpriseNodeId -TeamId $team.id
+        $projectedTeamSlug = $team.slug
+
+        $properties = [pscustomobject]@{
+            name                        = Normalize-Null $team.name
+            node_id                     = Normalize-Null $enterpriseTeamId
+            github_team_id              = Normalize-Null $team.id
+            environment_name            = Normalize-Null $enterpriseSlug
+            environmentid               = Normalize-Null $enterpriseNodeId
+            enterpriseid                = Normalize-Null $enterpriseNodeId
+            slug                        = Normalize-Null $team.slug
+            projected_slug              = Normalize-Null $projectedTeamSlug
+            description                 = Normalize-Null $team.description
+            created_at                  = Normalize-Null $team.created_at
+            updated_at                  = Normalize-Null $team.updated_at
+            query_enterprise            = "MATCH p=(:GH_Enterprise {node_id:'$enterpriseNodeId'})-[:GH_Contains]->(:GH_EnterpriseTeam {node_id:'$enterpriseTeamId'}) RETURN p"
+            query_assigned_organizations = "MATCH p=(:GH_EnterpriseTeam {node_id:'$enterpriseTeamId'})-[:GH_AssignedTo]->(:GH_Organization) RETURN p"
+            query_projected_teams       = "MATCH p=(:GH_EnterpriseTeam {node_id:'$enterpriseTeamId'})-[:GH_MemberOf]->(:GH_Team) RETURN p"
+            query_members               = "MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_TeamRole)-[:GH_MemberOf]->(:GH_EnterpriseTeam {node_id:'$enterpriseTeamId'}) RETURN p"
+        }
+
+        $null = $nodes.Add((New-GitHoundNode -Id $enterpriseTeamId -Kind 'GH_EnterpriseTeam' -Properties $properties))
+        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $enterpriseNodeId -EndId $enterpriseTeamId -Properties @{ traversable = $false }))
+
+        $membersRoleId = "${enterpriseTeamId}_members"
+        $membersRoleProps = [pscustomobject]@{
+            name             = Normalize-Null "$enterpriseSlug/$($team.slug)/members"
+            node_id          = Normalize-Null $membersRoleId
+            environment_name = Normalize-Null $enterpriseSlug
+            environmentid    = Normalize-Null $enterpriseNodeId
+            enterpriseid     = Normalize-Null $enterpriseNodeId
+            team_name        = Normalize-Null $team.name
+            team_id          = Normalize-Null $enterpriseTeamId
+            short_name       = Normalize-Null 'members'
+            type             = Normalize-Null 'team'
+            query_team       = "MATCH p=(:GH_TeamRole {node_id:'$membersRoleId'})-[:GH_MemberOf]->(:GH_EnterpriseTeam {node_id:'$enterpriseTeamId'}) RETURN p"
+            query_members    = "MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_TeamRole {node_id:'$membersRoleId'}) RETURN p"
+        }
+        $null = $nodes.Add((New-GitHoundNode -Id $membersRoleId -Kind 'GH_TeamRole', 'GH_Role' -Properties $membersRoleProps))
+        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $membersRoleId -EndId $enterpriseTeamId -Properties @{ traversable = $true }))
+
+        $members = @(Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/teams/$($team.id)/memberships")
+        foreach ($member in $members) {
+            if ($member.node_id) {
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $member.node_id -EndId $membersRoleId -Properties @{ traversable = $true }))
+            }
+        }
+
+        $assignedOrganizations = @(Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/teams/$($team.id)/organizations")
+        foreach ($org in $assignedOrganizations) {
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_AssignedTo' -StartId $enterpriseTeamId -EndId $org.node_id -Properties @{ traversable = $false }))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $enterpriseTeamId -EndKind 'GH_Team' -EndPropertyMatchers @(
+                (New-BHOGPropertyMatcher -Key 'environmentid' -Value $org.node_id),
+                (New-BHOGPropertyMatcher -Key 'slug' -Value $projectedTeamSlug)
+            ) -Properties @{ traversable = $true }))
+        }
+    }
+
+    Write-Host "[+] Git-HoundEnterpriseTeam complete. $($nodes.Count) nodes, $($edges.Count) edges."
 
     [PSCustomObject]@{
         Nodes = $nodes
@@ -2579,7 +2747,15 @@ function Git-HoundOrganization
 
         foreach($team in (Invoke-GithubRestMethod -Session $session -Path "orgs/$($org.login)/organization-roles/$($customRole.id)/teams"))
         {
-            $null = $edges.Add((New-GitHoundEdge -Kind GH_HasRole -StartId $team.node_id -EndId $customRoleId -Properties @{traversable=$true}))
+            $teamMatchers = Get-GitHoundOrganizationTeamPropertyMatchers -OrganizationId $org.node_id -TeamSlug $team.slug
+            if($teamMatchers)
+            {
+                $null = $edges.Add((New-GitHoundEdge -Kind GH_HasRole -StartKind 'GH_Team' -StartPropertyMatchers $teamMatchers -EndId $customRoleId -Properties @{traversable=$true}))
+            }
+            else
+            {
+                $null = $edges.Add((New-GitHoundEdge -Kind GH_HasRole -StartId $team.node_id -EndId $customRoleId -Properties @{traversable=$true}))
+            }
         }
 
         foreach($user in (Invoke-GithubRestMethod -Session $session -Path "orgs/$($org.login)/organization-roles/$($customRole.id)/users"))
@@ -2825,12 +3001,15 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
 
         foreach($team in $result.data.organization.teams.nodes)
         {
+            $teamNodeId = Get-GitHoundOrganizationTeamNodeId -OrganizationId $Organization.properties.node_id -TeamNodeId $team.id -TeamSlug $team.slug
+
             # --- Team Node ---
             $properties = [pscustomobject]@{
                 # Common Properties
                 #id                = Normalize-Null $team.databaseId
                 name              = Normalize-Null $team.name
-                node_id           = Normalize-Null $team.id
+                node_id           = Normalize-Null $teamNodeId
+                github_team_id    = Normalize-Null $team.id
                 # Relational Properties
                 environment_name  = Normalize-Null $Organization.properties.login
                 environmentid    = Normalize-Null $Organization.properties.node_id
@@ -2838,24 +3017,26 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
                 slug              = Normalize-Null $team.slug
                 description       = Normalize-Null $team.description
                 privacy           = Normalize-Null $team.privacy
+                type              = Normalize-Null $(if ($team.slug -like 'ent:*') { 'enterprise' } else { '' })
                 # Accordion Panel Queries
-                query_first_degree_members     = "MATCH p=(:GH_User)-[:GH_HasRole]->(t:GH_TeamRole)-[:GH_MemberOf]->(:GH_Team {node_id:'$($team.id)'}) RETURN p"
-                query_unrolled_members         = "MATCH p=(teamrole:GH_TeamRole)-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$($team.id)'}) MATCH p1 = (teamrole)<-[:GH_HasRole]-(:GH_User) RETURN p,p1"
-                query_first_degree_maintainers = "MATCH p=(:GH_User)-[:GH_HasRole]->(t:GH_TeamRole {short_name: 'maintainers'})-[:GH_MemberOf]->(:GH_Team {node_id:'$($team.id)'}) RETURN p"
-                query_unrolled_maintainers     = "MATCH p=(teamrole:GH_TeamRole {short_name: 'maintainers'})-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$($team.id)'}) MATCH p1 = (teamrole)<-[:GH_HasRole]-(:GH_User) RETURN p,p1"
-                query_repositories             = "MATCH p=(:GH_Team {node_id:'$($team.id)'})-[:GH_HasRole]->(:GH_RepoRole)-[]->(:GH_Repository) RETURN p"
-                query_child_teams              = "MATCH p=(:GH_Team)-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$($team.id)'}) RETURN p"
+                query_first_degree_members     = "MATCH p=(:GH_User)-[:GH_HasRole]->(t:GH_TeamRole)-[:GH_MemberOf]->(:GH_Team {node_id:'$teamNodeId'}) RETURN p"
+                query_unrolled_members         = "MATCH p=(teamrole:GH_TeamRole)-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$teamNodeId'}) MATCH p1 = (teamrole)<-[:GH_HasRole]-(:GH_User) RETURN p,p1"
+                query_first_degree_maintainers = "MATCH p=(:GH_User)-[:GH_HasRole]->(t:GH_TeamRole {short_name: 'maintainers'})-[:GH_MemberOf]->(:GH_Team {node_id:'$teamNodeId'}) RETURN p"
+                query_unrolled_maintainers     = "MATCH p=(teamrole:GH_TeamRole {short_name: 'maintainers'})-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$teamNodeId'}) MATCH p1 = (teamrole)<-[:GH_HasRole]-(:GH_User) RETURN p,p1"
+                query_repositories             = "MATCH p=(:GH_Team {node_id:'$teamNodeId'})-[:GH_HasRole]->(:GH_RepoRole)-[]->(:GH_Repository) RETURN p"
+                query_child_teams              = "MATCH p=(:GH_Team)-[:GH_MemberOf*1..]->(:GH_Team {node_id:'$teamNodeId'}) RETURN p"
             }
-            $null = $nodes.Add((New-GitHoundNode -Id $team.id -Kind 'GH_Team' -Properties $properties))
+            $null = $nodes.Add((New-GitHoundNode -Id $teamNodeId -Kind 'GH_Team' -Properties $properties))
 
             # Parent team edge
             if($null -ne $team.parentTeam)
             {
-                $null = $edges.Add((New-GitHoundEdge -Kind GH_MemberOf -StartId $team.id -EndId $team.parentTeam.id -Properties @{ traversable = $true }))
+                $parentTeamNodeId = Get-GitHoundOrganizationTeamNodeId -OrganizationId $Organization.properties.node_id -TeamNodeId $team.parentTeam.id -TeamSlug ''
+                $null = $edges.Add((New-GitHoundEdge -Kind GH_MemberOf -StartId $teamNodeId -EndId $parentTeamNodeId -Properties @{ traversable = $true }))
             }
 
             # --- Team Role Nodes (members and maintainers) ---
-            $memberId = "$($team.id)_members"
+            $memberId = "${teamNodeId}_members"
             $memberProps = [pscustomobject]@{
                 # Common Properties
                 name               = Normalize-Null "$($Organization.properties.login)/$($team.slug)/members"
@@ -2864,7 +3045,7 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
                 environment_name   = Normalize-Null $Organization.properties.login
                 environmentid     = Normalize-Null $Organization.properties.node_id
                 team_name          = Normalize-Null $team.name
-                team_id            = Normalize-Null $team.id
+                team_id            = Normalize-Null $teamNodeId
                 # Node Specific Properties
                 short_name         = Normalize-Null 'members'
                 type               = Normalize-Null 'team'
@@ -2874,9 +3055,9 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
                 query_repositories = "MATCH p=(:GH_TeamRole {node_id:'$($memberId)'})-[:GH_MemberOf]->(:GH_Team)-[:GH_HasRole|GH_HasBaseRole*1..]->(:GH_RepoRole)-[]->(:GH_Repository) RETURN p"
             }
             $null = $nodes.Add((New-GitHoundNode -Id $memberId -Kind 'GH_TeamRole','GH_Role' -Properties $memberProps))
-            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $memberId -EndId $team.id -Properties @{traversable=$true}))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $memberId -EndId $teamNodeId -Properties @{traversable=$true}))
 
-            $maintainerId = "$($team.id)_maintainers"
+            $maintainerId = "${teamNodeId}_maintainers"
             $maintainerProps = [pscustomobject]@{
                 # Common Properties
                 name               = Normalize-Null "$($Organization.properties.login)/$($team.slug)/maintainers"
@@ -2885,7 +3066,7 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
                 environment_name   = Normalize-Null $Organization.properties.login
                 environmentid     = Normalize-Null $Organization.properties.node_id
                 team_name          = Normalize-Null $team.name
-                team_id            = Normalize-Null $team.id
+                team_id            = Normalize-Null $teamNodeId
                 # Node Specific Properties
                 short_name         = Normalize-Null 'maintainers'
                 type               = Normalize-Null 'team'
@@ -2895,8 +3076,8 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
                 query_repositories = "MATCH p=(:GH_TeamRole {node_id:'$($maintainerId)'})-[:GH_MemberOf]->(:GH_Team)-[:GH_HasRole|GH_HasBaseRole*1..]->(:GH_RepoRole)-[]->(:GH_Repository) RETURN p"
             }
             $null = $nodes.Add((New-GitHoundNode -Id $maintainerId -Kind 'GH_TeamRole','GH_Role' -Properties $maintainerProps))
-            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $maintainerId -EndId $team.id -Properties @{traversable=$true}))
-            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_AddMember' -StartId $maintainerId -EndId $team.id -Properties @{traversable=$true}))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MemberOf' -StartId $maintainerId -EndId $teamNodeId -Properties @{traversable=$true}))
+            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_AddMember' -StartId $maintainerId -EndId $teamNodeId -Properties @{traversable=$true}))
 
             # --- Member Role Assignments (from first page of members) ---
             foreach($memberEdge in $team.members.edges)
@@ -2914,7 +3095,7 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
             {
                 $null = $overflowTeams.Add([PSCustomObject]@{
                     slug          = $team.slug
-                    teamId        = $team.id
+                    teamId        = $teamNodeId
                     memberId      = $memberId
                     maintainerId  = $maintainerId
                     endCursor     = $team.members.pageInfo.endCursor
@@ -2952,6 +3133,29 @@ query TeamMembersOverflow($login: String!, $slug: String!, $count: Int = 100, $a
             $overflowVars['after'] = $overflowResult.data.organization.team.members.pageInfo.endCursor
         }
         while($overflowResult.data.organization.team.members.pageInfo.hasNextPage)
+    }
+
+    # Phase 3: Enterprise-projected org teams visible via REST.
+    $restTeams = @(Invoke-GithubRestMethod -Session $Session -Path "orgs/$($Organization.properties.login)/teams")
+    foreach($team in @($restTeams | Where-Object { $_.slug -like 'ent:*' }))
+    {
+        $teamNodeId = Get-GitHoundOrganizationTeamNodeId -OrganizationId $Organization.properties.node_id -TeamNodeId $team.node_id -TeamSlug $team.slug
+
+        $properties = [pscustomobject]@{
+            name               = Normalize-Null $team.name
+            node_id            = Normalize-Null $teamNodeId
+            github_team_id     = Normalize-Null $team.node_id
+            collected          = $false
+            environment_name   = Normalize-Null $Organization.properties.login
+            environmentid      = Normalize-Null $Organization.properties.node_id
+            slug               = Normalize-Null $team.slug
+            description        = Normalize-Null $team.description
+            privacy            = Normalize-Null $team.privacy
+            type               = Normalize-Null 'enterprise'
+            query_repositories = "MATCH p=(:GH_Team {node_id:'$teamNodeId'})-[:GH_HasRole]->(:GH_RepoRole)-[]->(:GH_Repository) RETURN p"
+        }
+
+        $null = $nodes.Add((New-GitHoundNode -Id $teamNodeId -Kind 'GH_Team' -Properties $properties))
     }
 
     $output = [PSCustomObject]@{
@@ -3826,7 +4030,15 @@ function Git-HoundRepositoryRole
                         'pull'     { $repoRoleId = $repoReadId }
                         default    { $repoRoleId = "$($repo.properties.node_id)_$($team.permission)" }
                     }
-                    $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $team.node_id -EndId $repoRoleId -Properties @{traversable=$true}))
+                    $teamMatchers = Get-GitHoundOrganizationTeamPropertyMatchers -OrganizationId $repo.properties.environmentid -TeamSlug $team.slug
+                    if($teamMatchers)
+                    {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartKind 'GH_Team' -StartPropertyMatchers $teamMatchers -EndId $repoRoleId -Properties @{traversable=$true}))
+                    }
+                    else
+                    {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $team.node_id -EndId $repoRoleId -Properties @{traversable=$true}))
+                    }
                 }
             } -ThrottleLimit 25
 

--- a/schema.json
+++ b/schema.json
@@ -31,6 +31,14 @@
       "color": "#FF8E40"
     },
     {
+      "name": "GH_EnterpriseTeam",
+      "display_name": "GitHub Enterprise Team",
+      "description": "An enterprise-level team that can be assigned into one or more organizations and projected as organization teams",
+      "is_display_kind": true,
+      "icon": "users-between-lines",
+      "color": "#7C3AED"
+    },
+    {
       "name": "GH_Team",
       "display_name": "GitHub Team",
       "description": "A team within an organization, grouping users for shared access and collaboration",
@@ -259,6 +267,11 @@
     {
       "name": "GH_Contains",
       "description": "Container relationship for organizational hierarchy (org contains secrets/variables, repo contains secrets/variables, environment contains secrets/variables)",
+      "is_traversable": false
+    },
+    {
+      "name": "GH_AssignedTo",
+      "description": "Structural assignment relationship showing that an enterprise team is assigned to an organization",
       "is_traversable": false
     },
     {


### PR DESCRIPTION
- add GH_EnterpriseTeam as a first-class node kind for enterprise-scoped GitHub teams
- add GH_AssignedTo as a non-traversable structural edge from GH_EnterpriseTeam to GH_Organization
- add Git-HoundEnterpriseTeam to collect enterprise teams, their assigned organizations, and enterprise-team member assignments
- model enterprise team membership through a synthetic GH_TeamRole members node linked to GH_EnterpriseTeam with GH_MemberOf
- create GH_HasRole edges from GH_User to enterprise-team member roles using the enterprise team memberships API
- use the enterprise team organizations API to drive organization assignment from the enterprise perspective
- preserve native GH_Team object IDs by avoiding enterprise-side projected team stubs
- create GH_MemberOf edges from GH_EnterpriseTeam to org-visible ent: GH_Team nodes using property matching on organization and slug
- update org team, org custom-role team assignment, and repo team-role assignment paths to property-match ent: teams by environmentid + slug
- keep GH_Contains non-traversable for enterprise-to-enterprise-team containment
- document GH_EnterpriseTeam and GH_AssignedTo and update team, enterprise, contains, memberof, schema, query, and README docs to reflect the new enterprise team model