### PR TITLE
Add enterprise SCIM groups and separate enterprise sidecar outputs

### DIFF
--- a/Documentation/EdgeDescriptions/SCIM_Provisioned.md
+++ b/Documentation/EdgeDescriptions/SCIM_Provisioned.md
@@ -2,14 +2,19 @@
 
 ## Edge Schema
 
-- Source: `SCIM_User`
-- Destination: [GH_ExternalIdentity](../NodeDescriptions/GH_ExternalIdentity.md)
+- Source: `SCIM_User`, `SCIM_Group`
+- Destination: [GH_ExternalIdentity](../NodeDescriptions/GH_ExternalIdentity.md), [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md)
 
 ## General Information
 
-The traversable `SCIM_Provisioned` edge correlates a SCIM-provisioned user record to the matching GitHub external identity. In GitHound, this edge is created by `Git-HoundScimUser` and `Git-HoundEnterpriseScimUser` when a SCIM user can be matched to a `GH_ExternalIdentity` using both the SCIM resource identifier and the SCIM username.
+The traversable `SCIM_Provisioned` edge correlates SCIM-provisioned objects to the GitHub object they provision or represent. In GitHound today, that means:
 
-This edge is intentionally stronger than a loose name-only match. The current correlation uses:
+- `SCIM_User -> GH_ExternalIdentity`
+- `SCIM_Group -> GH_EnterpriseTeam`
+
+The user correlation is created by `Git-HoundScimUser` and `Git-HoundEnterpriseScimUser`. The group-to-team correlation is created by `Git-HoundEnterpriseScimGroup` when GitHub exposes a `group_id` on the matching enterprise team.
+
+For SCIM users, the correlation is intentionally stronger than a loose name-only match. The current correlation uses:
 
 - `SCIM_User.id`
 - `GH_ExternalIdentity.guid`
@@ -18,12 +23,23 @@ This edge is intentionally stronger than a loose name-only match. The current co
 
 That gives us a reliable bridge from the raw SCIM layer into GitHub's native external identity object without skipping straight to `GH_User`.
 
+For SCIM groups, the current enterprise correlation uses:
+
+- `SCIM_Group.id`
+- `GH_EnterpriseTeam.group_id`
+- shared `environmentid`
+
+That ties the generic SCIM group model into GitHub's enterprise team model using GitHub-native data rather than provider-specific guessing.
+
 ```mermaid
 graph LR
     scimUser("SCIM_User d3c9cc90-1e3a-11f1-9caf-aeaf7c29665a")
     extId("GH_ExternalIdentity grace.roberts@k-nexusglobal.com")
     ghUser("GH_User grace-roberts_knexus")
+    scimGroup("SCIM_Group Corp-Security")
+    entTeam("GH_EnterpriseTeam Corp-Security")
 
     scimUser -- SCIM_Provisioned --> extId
+    scimGroup -- SCIM_Provisioned --> entTeam
     extId -. GH_MapsToUser .-> ghUser
 ```

--- a/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
+++ b/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
@@ -14,14 +14,16 @@ Created by: `Git-HoundEnterpriseTeam`
 | github_team_id         | string    | The raw enterprise team id returned by the GitHub enterprise team API. |
 | environment_name       | string    | The enterprise slug. |
 | environmentid          | string    | The enterprise node id. |
-| enterpriseid           | string    | The enterprise node id, repeated explicitly for enterprise-scoped matching. |
 | slug                   | string    | The enterprise team slug. |
 | projected_slug         | string    | The projected organization team slug, typically using the `ent:` prefix. |
+| group_id               | string    | When present, the SCIM group id GitHub associates with this enterprise team. |
 | description            | string    | The team description. |
 | created_at             | string    | When the enterprise team was created. |
 | updated_at             | string    | When the enterprise team was last updated. |
 
 Enterprise team membership is represented through a synthetic `GH_TeamRole` node (`members`) linked with `GH_MemberOf`. Organization assignment is represented with `GH_AssignedTo`, and the enterprise team is linked to org-visible `ent:` teams with a property-matched `GH_MemberOf` edge once those organization teams exist in the graph.
+
+When GitHub exposes a `group_id` on the enterprise team, GitHound can also tie the GitHub enterprise team model back to the shared SCIM schema by correlating `SCIM_Group` to `GH_EnterpriseTeam` with `SCIM_Provisioned`. That gives us a native bridge from SCIM-provisioned groups into the GitHub enterprise team model without relying on provider-specific assumptions.
 
 ## Diagram
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ Enterprise team collection through `Git-HoundEnterpriseTeam` adds:
 - `GH_MemberOf` edges from enterprise teams to org-visible `ent:` `GH_Team` nodes using property matching
 - enterprise-team `members` roles and `GH_HasRole` edges from users to those roles
 
+Enterprise SCIM collection currently adds:
+
+- `SCIM_User`
+- `SCIM_Group`
+- `SCIM_Provisioned` from `SCIM_User` to `GH_ExternalIdentity`
+- `SCIM_Provisioned` from `SCIM_Group` to `GH_EnterpriseTeam` when GitHub exposes the enterprise team `group_id`
+- `SCIM_MemberOf` from `SCIM_User` to `SCIM_Group`
+
+This gives GitHound a provider-agnostic bridge from the shared SCIM schema into GitHub's native enterprise identity and team model.
+
 The `GH_Organization` stubs emitted by enterprise collection are intentionally marked
 `collected = false`. They represent structural discovery from the enterprise context and are
 meant to be enriched later by normal organization collection.

--- a/githound.ps1
+++ b/githound.ps1
@@ -1419,9 +1419,9 @@ function Git-HoundEnterpriseTeam
             github_team_id              = Normalize-Null $team.id
             environment_name            = Normalize-Null $enterpriseSlug
             environmentid               = Normalize-Null $enterpriseNodeId
-            enterpriseid                = Normalize-Null $enterpriseNodeId
             slug                        = Normalize-Null $team.slug
             projected_slug              = Normalize-Null $projectedTeamSlug
+            group_id                    = Normalize-Null $team.group_id
             description                 = Normalize-Null $team.description
             created_at                  = Normalize-Null $team.created_at
             updated_at                  = Normalize-Null $team.updated_at
@@ -7968,7 +7968,11 @@ function Git-HoundEnterpriseScimUser
     Param(
         [Parameter(Position = 0, Mandatory = $true)]
         [PSTypeName('GitHound.Session')]
-        $Session
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $false)]
+        [PSObject]
+        $Enterprise
     )
 
     if (-not $Session.EnterpriseName) {
@@ -7983,6 +7987,13 @@ function Git-HoundEnterpriseScimUser
     $edges = New-Object System.Collections.ArrayList
 
     $enterpriseSlug = $Session.EnterpriseName
+    $enterpriseNodeId = if ($Enterprise -and $Enterprise.properties -and $Enterprise.properties.node_id) {
+        $Enterprise.properties.node_id
+    } elseif ($Enterprise -and $Enterprise.id) {
+        $Enterprise.id
+    } else {
+        $enterpriseSlug
+    }
     $startIndex = 1
 
     do
@@ -8027,7 +8038,7 @@ function Git-HoundEnterpriseScimUser
                 mail          = Normalize-Null ($scimIdentity.emails | Where-Object { $_.primary -eq $true }).value
                 enterprise    = Normalize-Null $enterpriseSlug
                 environment_name = Normalize-Null $enterpriseSlug
-                environmentid    = Normalize-Null $enterpriseSlug
+                environmentid    = Normalize-Null $enterpriseNodeId
             }
 
             $null = $nodes.Add((New-GitHoundNode -Kind SCIM_User -Id $scimIdentity.id -Properties $props))
@@ -8035,6 +8046,114 @@ function Git-HoundEnterpriseScimUser
             if (($props.enabled -eq $true) -and -not [string]::IsNullOrWhiteSpace($scimIdentity.externalId) -and -not [string]::IsNullOrWhiteSpace($scimIdentity.userName)) {
                 $externalIdentityMatchers = Get-GitHoundScimExternalIdentityPropertyMatchers -Guid $scimIdentity.id -Username $scimIdentity.userName
                 $null = $edges.Add((New-GitHoundEdge -Kind SCIM_Provisioned -StartId $scimIdentity.id -EndKind GH_ExternalIdentity -EndPropertyMatchers $externalIdentityMatchers -Properties @{ traversable = $true }))
+            }
+        }
+
+        $startIndex = $result.startIndex + $result.itemsPerPage
+    } while($startIndex -lt $result.totalResults)
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
+}
+
+function Git-HoundEnterpriseScimGroup
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $false)]
+        [PSObject]
+        $Enterprise
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterpriseScimGroup requires Session.EnterpriseName to be set."
+    }
+
+    if (-not $Session.PatHeaders) {
+        throw "Git-HoundEnterpriseScimGroup requires a PAT-backed session."
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $enterpriseSlug = $Session.EnterpriseName
+    $enterpriseNodeId = if ($Enterprise -and $Enterprise.properties -and $Enterprise.properties.node_id) {
+        $Enterprise.properties.node_id
+    } elseif ($Enterprise -and $Enterprise.id) {
+        $Enterprise.id
+    } else {
+        $enterpriseSlug
+    }
+    $startIndex = 1
+
+    do
+    {
+        try {
+            $responseBytes = Invoke-GithubRestMethod `
+                -Session $Session `
+                -Headers $Session.PatHeaders `
+                -Path "scim/v2/enterprises/$enterpriseSlug/Groups?startIndex=$($startIndex)" `
+                -ErrorMode Stop
+        }
+        catch {
+            $errorInfo = Get-GitHoundRestErrorInfo -ErrorRecord $_ -Path "scim/v2/enterprises/$enterpriseSlug/Groups?startIndex=$($startIndex)"
+            Write-GitHoundRestSkipWarning -Target $enterpriseSlug -Feature "enterprise SCIM groups" -ErrorInfo $errorInfo
+            return [PSCustomObject]@{
+                Nodes = $nodes
+                Edges = $edges
+            }
+        }
+
+        if (-not $responseBytes) {
+            Write-Warning "Skipping enterprise SCIM groups for '$enterpriseSlug': GitHub returned an empty response."
+            return [PSCustomObject]@{
+                Nodes = $nodes
+                Edges = $edges
+            }
+        }
+
+        $result = [System.Text.Encoding]::ASCII.GetString($responseBytes) | ConvertFrom-Json
+        foreach($scimGroup in $result.Resources)
+        {
+            $props = [pscustomobject]@{
+                name             = Normalize-Null $scimGroup.displayName
+                id               = Normalize-Null $scimGroup.id
+                externalId       = Normalize-Null $scimGroup.externalId
+                displayName      = Normalize-Null $scimGroup.displayName
+                profileUrl       = Normalize-Null $scimGroup.meta.location
+                created          = Normalize-Null $scimGroup.meta.created
+                lastModified     = Normalize-Null $scimGroup.meta.lastModified
+                resourceType     = Normalize-Null $scimGroup.meta.resourceType
+                schemas          = Normalize-Null ($scimGroup.schemas -join ',')
+                memberCount      = @($scimGroup.members).Count
+                memberIds        = Normalize-Null ((@($scimGroup.members | ForEach-Object { $_.value }) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ',')
+                memberNames      = Normalize-Null ((@($scimGroup.members | ForEach-Object { $_.display }) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ',')
+                enterprise       = Normalize-Null $enterpriseSlug
+                environment_name = Normalize-Null $enterpriseSlug
+                environmentid    = Normalize-Null $enterpriseNodeId
+            }
+
+            $null = $nodes.Add((New-GitHoundNode -Kind SCIM_Group -Id $scimGroup.id -Properties $props))
+
+            if (-not [string]::IsNullOrWhiteSpace($scimGroup.id)) {
+                $enterpriseTeamMatchers = @(
+                    (New-BHOGPropertyMatcher -Key 'group_id' -Value $scimGroup.id),
+                    (New-BHOGPropertyMatcher -Key 'environmentid' -Value $enterpriseNodeId)
+                )
+
+                $null = $edges.Add((New-GitHoundEdge -Kind SCIM_Provisioned -StartId $scimGroup.id -EndKind GH_EnterpriseTeam -EndPropertyMatchers $enterpriseTeamMatchers -Properties @{ traversable = $true }))
+            }
+
+            foreach ($member in @($scimGroup.members)) {
+                if (-not [string]::IsNullOrWhiteSpace($member.value)) {
+                    $null = $edges.Add((New-GitHoundEdge -Kind SCIM_MemberOf -StartId $member.value -EndId $scimGroup.id -Properties @{ traversable = $true }))
+                }
             }
         }
 
@@ -9117,25 +9236,63 @@ function Invoke-GitHoundEnterprise
     if($enterpriseTeams.Edges) { $edges.AddRange(@($enterpriseTeams.Edges)) }
 
     # ── Step 4: Enterprise SCIM Users ────────────────────────────────────
+    $enterpriseScimUsers = [PSCustomObject]@{
+        Nodes = @()
+        Edges = @()
+    }
+    $enterpriseScimGroups = [PSCustomObject]@{
+        Nodes = @()
+        Edges = @()
+    }
+
     if ($Session.HasPersonalAccessToken) {
-        $stepFile = Join-Path $CheckpointPath "githound_enterprise_scim_$entId.json"
+        $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSCIMUser_$entId.json"
         if ($Resume -and (Test-Path $stepFile)) {
-            Write-Host "[*] Resuming: Loaded Enterprise SCIM Users from githound_enterprise_scim_$entId.json"
+            Write-Host "[*] Resuming: Loaded Enterprise SCIM Users from githound_EnterpriseSCIMUser_$entId.json"
             $enterpriseScimUsers = Import-GitHoundStepOutput -FilePath $stepFile
         } else {
             Write-Host "[*] Enumerating Enterprise SCIM Users"
-            $enterpriseScimUsers = Git-HoundEnterpriseScimUser -Session $Session
+            $enterpriseScimUsers = Git-HoundEnterpriseScimUser -Session $Session -Enterprise $enterprise.Nodes[0]
             Export-GitHoundStepOutput -StepResult $enterpriseScimUsers -FilePath $stepFile
-            Write-Host "[+] Saved: githound_enterprise_scim_$entId.json"
+            Write-Host "[+] Saved: githound_EnterpriseSCIMUser_$entId.json"
         }
 
-        if($enterpriseScimUsers.Nodes) { $nodes.AddRange(@($enterpriseScimUsers.Nodes)) }
-        if($enterpriseScimUsers.Edges) { $edges.AddRange(@($enterpriseScimUsers.Edges)) }
     } else {
         Write-Host "[*] Skipping Enterprise SCIM Users (session does not contain a PAT)"
     }
 
-    # ── Step 5: Enterprise SAML (separate output) ────────────────────────
+    # ── Step 5: Enterprise SCIM Groups ───────────────────────────────────
+    if ($Session.HasPersonalAccessToken) {
+        $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSCIMGroup_$entId.json"
+        if ($Resume -and (Test-Path $stepFile)) {
+            Write-Host "[*] Resuming: Loaded Enterprise SCIM Groups from githound_EnterpriseSCIMGroup_$entId.json"
+            $enterpriseScimGroups = Import-GitHoundStepOutput -FilePath $stepFile
+        } else {
+            Write-Host "[*] Enumerating Enterprise SCIM Groups"
+            $enterpriseScimGroups = Git-HoundEnterpriseScimGroup -Session $Session -Enterprise $enterprise.Nodes[0]
+            Export-GitHoundStepOutput -StepResult $enterpriseScimGroups -FilePath $stepFile
+            Write-Host "[+] Saved: githound_EnterpriseSCIMGroup_$entId.json"
+        }
+
+    } else {
+        Write-Host "[*] Skipping Enterprise SCIM Groups (session does not contain a PAT)"
+    }
+
+    if ($Session.HasPersonalAccessToken) {
+        $scimNodes = @(@($enterpriseScimUsers.Nodes) + @($enterpriseScimGroups.Nodes) | Where-Object { $_ -ne $null })
+        $scimEdges = @(@($enterpriseScimUsers.Edges) + @($enterpriseScimGroups.Edges) | Where-Object { $_ -ne $null })
+        $scimPayload = [PSCustomObject]@{
+            '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
+            graph = [PSCustomObject]@{
+                nodes = $scimNodes
+                edges = $scimEdges
+            }
+        }
+        $scimPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_scim_$entId.json")
+        Write-Host "[+] SCIM payload: githound_scim_$entId.json ($($scimNodes.Count) nodes, $($scimEdges.Count) edges)"
+    }
+
+    # ── Step 6: Enterprise SAML (separate output) ────────────────────────
     if ($Session.HasPersonalAccessToken) {
         $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSaml_$entId.json"
         if ($Resume -and (Test-Path $stepFile)) {
@@ -9155,7 +9312,7 @@ function Invoke-GitHoundEnterprise
                 edges = @($enterpriseSaml.Edges | Where-Object { $_ -ne $null })
             }
         }
-        $enterpriseSamlPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_enterprise_saml_$entId.json")
+        $enterpriseSamlPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_saml_$entId.json")
     } else {
         Write-Host "[*] Skipping Enterprise SAML (session does not contain a PAT)"
     }
@@ -9174,8 +9331,8 @@ function Invoke-GitHoundEnterprise
             edges = $filteredEdges
         }
     }
-    $enterprisePayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_enterprise_$entId.json")
-    Write-Host "[+] Enterprise payload: githound_enterprise_$entId.json ($($filteredNodes.Count) nodes, $($filteredEdges.Count) edges)"
+    $enterprisePayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_$entId.json")
+    Write-Host "[+] Enterprise payload: githound_$entId.json ($($filteredNodes.Count) nodes, $($filteredEdges.Count) edges)"
 
     if ($EnterpriseOnly) {
         if ($CleanupIntermediates) {
@@ -9183,7 +9340,8 @@ function Invoke-GitHoundEnterprise
                 "githound_Enterprise_$entId.json",
                 "githound_EnterpriseUser_$entId.json",
                 "githound_EnterpriseTeam_$entId.json",
-                "githound_enterprise_scim_$entId.json",
+                "githound_EnterpriseSCIMUser_$entId.json",
+                "githound_EnterpriseSCIMGroup_$entId.json",
                 "githound_EnterpriseSaml_$entId.json"
             )
 
@@ -9251,7 +9409,8 @@ function Invoke-GitHoundEnterprise
             "githound_Enterprise_$entId.json",
             "githound_EnterpriseUser_$entId.json",
             "githound_EnterpriseTeam_$entId.json",
-            "githound_enterprise_scim_$entId.json",
+            "githound_EnterpriseSCIMUser_$entId.json",
+            "githound_EnterpriseSCIMGroup_$entId.json",
             "githound_EnterpriseSaml_$entId.json"
         )
 


### PR DESCRIPTION
- add Git-HoundEnterpriseScimGroup to collect enterprise SCIM groups from the enterprise SCIM API using PAT-backed sessions
- create SCIM_Group nodes for enterprise-provisioned groups and preserve a broader set of group properties including displayName, externalId, profileUrl, timestamps, schemas, and member summary fields
- add SCIM_MemberOf edges from SCIM_User to SCIM_Group using SCIM group membership data from the enterprise SCIM response
- add SCIM_Provisioned edges from SCIM_Group to GH_EnterpriseTeam using property matching on group_id + environmentid
- restore group_id on GH_EnterpriseTeam so GitHub-native SCIM group to enterprise-team correlation can be preserved

- update enterprise SCIM collectors to use the actual GH_Enterprise node id as environmentid instead of the enterprise slug when the enterprise node is available
- remove redundant enterpriseid from GH_EnterpriseTeam to rely on environmentid as the canonical enterprise scope property

- rename enterprise SCIM intermediate checkpoint files to:
  - githound_EnterpriseSCIMUser_<entId>.json
  - githound_EnterpriseSCIMGroup_<entId>.json
- consolidate enterprise SCIM output into githound_scim_<entId>.json
- rename the consolidated enterprise SAML output to githound_saml_<entId>.json
- rename the consolidated enterprise GitHub-native output to githound_<entId>.json to avoid cleanup collisions with githound_Enterprise_<entId>.json

- keep SCIM-related nodes and edges out of the consolidated enterprise GitHub-native output so:
  - githound_<entId>.json contains GitHub-native enterprise data
  - githound_scim_<entId>.json contains SCIM nodes and bridge edges
  - githound_saml_<entId>.json contains SAML and external identity data

- update documentation to explain how GitHound ties the GitHub enterprise team model to the generic SCIM group model through SCIM_Provisioned
- update GH_EnterpriseTeam documentation to reflect group_id-based SCIM correlation and remove the redundant enterpriseid property description