### PR TITLE
Add Okta-aware SCIM correlation from SAML provider context

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ Enterprise SCIM collection currently adds:
 
 This gives GitHound a provider-agnostic bridge from the shared SCIM schema into GitHub's native enterprise identity and team model.
 
+When a collected `GH_SamlIdentityProvider` identifies the upstream IdP, GitHound can also add provider-aware SCIM correlation edges inside the SCIM sidecar output:
+
+- `Okta_User -> SCIM_User`
+  - matched by `Okta_User.id = SCIM_User.externalId`
+- `Okta_Group -> SCIM_Group`
+  - matched by `Okta_Group.name = SCIM_Group.externalId`
+  - and `Okta_Group.oktaDomain = GH_SamlIdentityProvider.foreign_environmentid`
+
+GitHound keeps the SCIM layer in its own sidecar output so these mappings remain visible without mixing SCIM-native nodes into the main GitHub-native enterprise graph:
+
+- `githound_<entId>.json` contains enterprise GitHub-native data
+- `githound_scim_<entId>.json` contains SCIM-native nodes and SCIM bridge edges
+- `githound_saml_<entId>.json` contains SAML and external identity data
+
 The `GH_Organization` stubs emitted by enterprise collection are intentionally marked
 `collected = false`. They represent structural discovery from the enterprise context and are
 meant to be enriched later by normal organization collection.

--- a/githound.ps1
+++ b/githound.ps1
@@ -933,6 +933,127 @@ function Get-GitHoundScimExternalIdentityPropertyMatchers
     )
 }
 
+function Get-GitHoundSamlProviderContext
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSObject]$SamlProviderNode
+    )
+
+    $issuer = $SamlProviderNode.properties.issuer
+    $ssoUrl = $SamlProviderNode.properties.sso_url
+    $foreignEnvironmentId = $SamlProviderNode.properties.foreign_environmentid
+    $environmentId = $SamlProviderNode.properties.environmentid
+
+    $scopeKind = if ($environmentId -like 'E_*') {
+        'enterprise'
+    } elseif ($environmentId -like 'O_*') {
+        'organization'
+    } else {
+        'unknown'
+    }
+
+    $idpKind = 'unknown'
+    $foreignUserNodeKind = $null
+    $foreignGroupNodeKind = $null
+
+    switch -Wildcard ($issuer) {
+        'https://auth.pingone.com/*' {
+            $idpKind = 'pingone'
+            $foreignUserNodeKind = 'PingOneUser'
+        }
+        'https://sts.windows.net/*' {
+            $idpKind = 'azure'
+            $foreignUserNodeKind = 'AZUser'
+        }
+        'http://www.okta.com/*' {
+            $idpKind = 'okta'
+            $foreignUserNodeKind = 'Okta_User'
+            $foreignGroupNodeKind = 'Okta_Group'
+            if (-not $foreignEnvironmentId -and $ssoUrl) {
+                $foreignEnvironmentId = $ssoUrl.Split('/')[2]
+            }
+        }
+    }
+
+    [PSCustomObject]@{
+        IdpKind              = $idpKind
+        ScopeKind            = $scopeKind
+        EnvironmentId        = $environmentId
+        EnvironmentName      = $SamlProviderNode.properties.environment_name
+        ForeignEnvironmentId = $foreignEnvironmentId
+        ForeignUserNodeKind  = $foreignUserNodeKind
+        ForeignGroupNodeKind = $foreignGroupNodeKind
+        SupportsScimUsers    = ($idpKind -ne 'unknown')
+        SupportsScimGroups   = ($idpKind -eq 'okta' -and $scopeKind -eq 'enterprise')
+    }
+}
+
+function Get-GitHoundOktaGroupPropertyMatchers
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OktaDomain
+    )
+
+    @(
+        (New-BHOGPropertyMatcher -Key 'name' -Value $Name),
+        (New-BHOGPropertyMatcher -Key 'oktaDomain' -Value $OktaDomain)
+    )
+}
+
+function Resolve-GitHoundScimIdpCorrelations
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSObject]$ScimResult,
+
+        [Parameter(Mandatory = $true)]
+        [PSObject]$SamlResult
+    )
+
+    $edges = New-Object System.Collections.ArrayList
+
+    $samlProviderNodes = @($SamlResult.Nodes | Where-Object { $_.kinds -contains 'GH_SamlIdentityProvider' })
+    if (-not $samlProviderNodes) {
+        return [PSCustomObject]@{ Nodes = @(); Edges = $edges }
+    }
+
+    $contexts = @($samlProviderNodes | ForEach-Object { Get-GitHoundSamlProviderContext -SamlProviderNode $_ })
+    $oktaContexts = @($contexts | Where-Object { $_.IdpKind -eq 'okta' })
+    if (-not $oktaContexts) {
+        return [PSCustomObject]@{ Nodes = @(); Edges = $edges }
+    }
+
+    foreach ($context in $oktaContexts) {
+        if ($context.SupportsScimUsers) {
+            foreach ($scimUser in @($ScimResult.Nodes | Where-Object { $_.kinds -contains 'SCIM_User' })) {
+                if (($scimUser.properties.enabled -eq $true) -and -not [string]::IsNullOrWhiteSpace($scimUser.properties.externalId)) {
+                    $null = $edges.Add((New-GitHoundEdge -Kind 'SCIM_Provisioned' -StartId $scimUser.properties.externalId -StartKind 'Okta_User' -EndId $scimUser.id -Properties @{ traversable = $true }))
+                }
+            }
+        }
+
+        if ($context.SupportsScimGroups -and -not [string]::IsNullOrWhiteSpace($context.ForeignEnvironmentId)) {
+            foreach ($scimGroup in @($ScimResult.Nodes | Where-Object { $_.kinds -contains 'SCIM_Group' })) {
+                if (-not [string]::IsNullOrWhiteSpace($scimGroup.properties.externalId)) {
+                    $oktaGroupMatchers = Get-GitHoundOktaGroupPropertyMatchers -Name $scimGroup.properties.externalId -OktaDomain $context.ForeignEnvironmentId
+                    $null = $edges.Add((New-GitHoundEdge -Kind 'SCIM_Provisioned' -StartKind 'Okta_Group' -StartPropertyMatchers $oktaGroupMatchers -EndId $scimGroup.id -Properties @{ traversable = $true }))
+                }
+            }
+        }
+    }
+
+    [PSCustomObject]@{
+        Nodes = @()
+        Edges = $edges
+    }
+}
+
 function Import-GitHoundStepOutput
 {
     <#
@@ -9042,6 +9163,9 @@ function Invoke-GitHound
         if($scim.nodes) { $scimNodes.AddRange(@($scim.nodes)) }
         if($scim.edges) { $scimEdges.AddRange(@($scim.edges)) }
 
+        $scimCorrelations = Resolve-GitHoundScimIdpCorrelations -ScimResult $scim -SamlResult $saml
+        if($scimCorrelations.Edges) { $scimEdges.AddRange(@($scimCorrelations.Edges)) }
+
         $payload = [PSCustomObject]@{
             '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
             graph = [PSCustomObject]@{
@@ -9278,20 +9402,6 @@ function Invoke-GitHoundEnterprise
         Write-Host "[*] Skipping Enterprise SCIM Groups (session does not contain a PAT)"
     }
 
-    if ($Session.HasPersonalAccessToken) {
-        $scimNodes = @(@($enterpriseScimUsers.Nodes) + @($enterpriseScimGroups.Nodes) | Where-Object { $_ -ne $null })
-        $scimEdges = @(@($enterpriseScimUsers.Edges) + @($enterpriseScimGroups.Edges) | Where-Object { $_ -ne $null })
-        $scimPayload = [PSCustomObject]@{
-            '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
-            graph = [PSCustomObject]@{
-                nodes = $scimNodes
-                edges = $scimEdges
-            }
-        }
-        $scimPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_scim_$entId.json")
-        Write-Host "[+] SCIM payload: githound_scim_$entId.json ($($scimNodes.Count) nodes, $($scimEdges.Count) edges)"
-    }
-
     # ── Step 6: Enterprise SAML (separate output) ────────────────────────
     if ($Session.HasPersonalAccessToken) {
         $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSaml_$entId.json"
@@ -9313,6 +9423,26 @@ function Invoke-GitHoundEnterprise
             }
         }
         $enterpriseSamlPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_saml_$entId.json")
+
+        $scimNodes = @(@($enterpriseScimUsers.Nodes) + @($enterpriseScimGroups.Nodes) | Where-Object { $_ -ne $null })
+        $scimEdges = @(@($enterpriseScimUsers.Edges) + @($enterpriseScimGroups.Edges) | Where-Object { $_ -ne $null })
+        $scimRaw = [PSCustomObject]@{
+            Nodes = $scimNodes
+            Edges = $scimEdges
+        }
+        $scimCorrelations = Resolve-GitHoundScimIdpCorrelations -ScimResult $scimRaw -SamlResult $enterpriseSaml
+        if($scimCorrelations.Edges) {
+            $scimEdges = @(@($scimEdges) + @($scimCorrelations.Edges) | Where-Object { $_ -ne $null })
+        }
+        $scimPayload = [PSCustomObject]@{
+            '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
+            graph = [PSCustomObject]@{
+                nodes = $scimNodes
+                edges = $scimEdges
+            }
+        }
+        $scimPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_scim_$entId.json")
+        Write-Host "[+] SCIM payload: githound_scim_$entId.json ($($scimNodes.Count) nodes, $($scimEdges.Count) edges)"
     } else {
         Write-Host "[*] Skipping Enterprise SAML (session does not contain a PAT)"
     }


### PR DESCRIPTION
- add shared SAML provider context resolution so GitHound can determine IdP kind, scope, and foreign environment from collected GH_SamlIdentityProvider nodes
- add Resolve-GitHoundScimIdpCorrelations as a shared post-processing step for SCIM sidecar outputs
- apply the shared SCIM/IdP correlation step to both organization and enterprise SCIM flows

- add Okta-aware SCIM user correlation:
  - create SCIM_Provisioned from Okta_User to SCIM_User
  - match by Okta user id using SCIM_User.externalId

- add Okta-aware SCIM group correlation:
  - create SCIM_Provisioned from Okta_Group to SCIM_Group
  - match by Okta group name using SCIM_Group.externalId
  - scope the match with oktaDomain from GH_SamlIdentityProvider.foreign_environmentid

- keep the correlation logic provider-aware by deriving behavior from the collected SAML identity provider rather than hardcoding collector-specific assumptions
- update README to explain how GitHound correlates Okta identities into the SCIM sidecar model