### PR TITLE
Add enterprise managed user support to enterprise member collection

### DIFF
--- a/Documentation/EdgeDescriptions/GH_HasMember.md
+++ b/Documentation/EdgeDescriptions/GH_HasMember.md
@@ -3,17 +3,19 @@
 ## Edge Schema
 
 - Source: [GH_Enterprise](../NodeDescriptions/GH_Enterprise.md), [GH_Organization](../NodeDescriptions/GH_Organization.md)
-- Destination: [GH_User](../NodeDescriptions/GH_User.md)
+- Destination: [GH_User](../NodeDescriptions/GH_User.md), [GH_EnterpriseManagedUser](../NodeDescriptions/GH_EnterpriseManagedUser.md)
 
 ## General Information
 
-The non-traversable [GH_HasMember](GH_HasMember.md) edge represents direct membership of a user in an enterprise or organization. This edge is structural and identity-oriented rather than privilege-bearing: it shows that the user belongs to the scope, but it does not by itself grant any permissions.
+The non-traversable [GH_HasMember](GH_HasMember.md) edge represents direct membership of a principal in an enterprise or organization. This edge is structural and identity-oriented rather than privilege-bearing: it shows that the principal belongs to the scope, but it does not by itself grant any permissions.
 
-At the enterprise level, this edge is created by `Git-HoundEnterpriseUser` from the GraphQL `enterprise.members` connection. Organization-level membership remains primarily modeled through default organization roles today, but `GH_HasMember` is the appropriate semantic edge when direct membership is collected as first-class data.
+At the enterprise level, this edge is created by `Git-HoundEnterpriseUser` from the GraphQL `enterprise.members` connection. In traditional-account environments it points directly to `GH_User`. In enterprise-managed-user environments it points to `GH_EnterpriseManagedUser`, which can then map to the traditional `GH_User` with `GH_MapsToUser`. Organization-level membership remains primarily modeled through default organization roles today, but `GH_HasMember` is the appropriate semantic edge when direct membership is collected as first-class data.
 
 ```mermaid
 graph LR
     ent("GH_Enterprise Example-Enterprise")
     user("GH_User alice")
+    emu("GH_EnterpriseManagedUser alice@example.com")
     ent -- GH_HasMember --> user
+    ent -- GH_HasMember --> emu
 ```

--- a/Documentation/EdgeDescriptions/GH_MapsToUser.md
+++ b/Documentation/EdgeDescriptions/GH_MapsToUser.md
@@ -2,12 +2,18 @@
 
 ## Edge Schema
 
-- Source: [GH_ExternalIdentity](../NodeDescriptions/GH_ExternalIdentity.md)
+- Source: [GH_ExternalIdentity](../NodeDescriptions/GH_ExternalIdentity.md), [GH_EnterpriseManagedUser](../NodeDescriptions/GH_EnterpriseManagedUser.md)
 - Destination: [GH_User](../NodeDescriptions/GH_User.md)
 
 ## General Information
 
-The non-traversable [GH_MapsToUser](GH_MapsToUser.md) edge maps a GitHub external identity to either a GitHub user within the organization or enterprise, or to an external IdP user (such as [AZUser](https://bloodhound.specterops.io/resources/nodes/az-user), [Okta_User](https://bloodhound.specterops.io/opengraph/extensions/oktahound/reference/nodes/okta_user), or [PingOneUser](https://github.com/andyrobbins/PingOneHound?tab=readme-ov-file#schema)) in hybrid graph scenarios. It is created by `Git-HoundGraphQlSamlProvider` and `Git-HoundEnterpriseSamlProvider`. SCIM user records correlate to `GH_ExternalIdentity` via `SCIM_Provisioned`, not `GH_MapsToUser`. This edge represents identity correlation rather than an attack path, connecting a user's external IdP account to their GitHub account for visibility into federated identity mappings.
+The non-traversable [GH_MapsToUser](GH_MapsToUser.md) edge maps a GitHub-side identity wrapper to the corresponding GitHub user, or maps a GitHub external identity to an external IdP user in hybrid graph scenarios. In GitHound today, that includes:
+
+- `GH_ExternalIdentity -> GH_User`
+- `GH_ExternalIdentity -> AZUser | Okta_User | PingOneUser`
+- `GH_EnterpriseManagedUser -> GH_User`
+
+It is created by `Git-HoundGraphQlSamlProvider`, `Git-HoundEnterpriseSamlProvider`, and `Git-HoundEnterpriseUser`. SCIM user records correlate to `GH_ExternalIdentity` via `SCIM_Provisioned`, not `GH_MapsToUser`. This edge represents identity correlation rather than an attack path, connecting a wrapper identity object to the GitHub principal it represents.
 
 ```mermaid
 graph LR

--- a/Documentation/NodeDescriptions/GH_Enterprise.md
+++ b/Documentation/NodeDescriptions/GH_Enterprise.md
@@ -26,7 +26,7 @@ Created by: `Git-HoundEnterprise`
 | security_contact_email| string    | The enterprise security contact email, when available.                                          |
 | viewer_is_admin       | boolean   | Whether the authenticated principal is an enterprise admin.                                     |
 
-Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes. Enterprise team collection adds `GH_EnterpriseTeam` nodes, links them with `GH_Contains`, and models organization assignment separately with `GH_AssignedTo`.
+Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes in traditional-account environments, and to `GH_EnterpriseManagedUser` nodes in enterprise-managed-user environments. Enterprise-managed users then map back to `GH_User` with `GH_MapsToUser`. Enterprise team collection adds `GH_EnterpriseTeam` nodes, links them with `GH_Contains`, and models organization assignment separately with `GH_AssignedTo`.
 
 ## Diagram
 
@@ -35,9 +35,12 @@ flowchart TD
     GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
     GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
+    GH_EnterpriseManagedUser[fa:fa-user-lock GH_EnterpriseManagedUser]
     GH_User[fa:fa-user GH_User]
 
     GH_Enterprise -.->|GH_Contains| GH_Organization
     GH_Enterprise -.->|GH_Contains| GH_EnterpriseTeam
     GH_Enterprise -.->|GH_HasMember| GH_User
+    GH_Enterprise -.->|GH_HasMember| GH_EnterpriseManagedUser
+    GH_EnterpriseManagedUser -.->|GH_MapsToUser| GH_User
 ```

--- a/Documentation/NodeDescriptions/GH_EnterpriseManagedUser.md
+++ b/Documentation/NodeDescriptions/GH_EnterpriseManagedUser.md
@@ -1,0 +1,36 @@
+# <img src="../Icons/gh_enterprisemanageduser.png" width="50"/> GH_EnterpriseManagedUser
+
+Represents a GitHub enterprise-managed account wrapper returned as `EnterpriseUserAccount` from the enterprise members GraphQL API. This node captures the managed account object itself, while a corresponding `GH_User` node represents the traditional GitHub user principal when GitHub returns the nested `user` object.
+
+Created by: `Git-HoundEnterpriseUser`
+
+## Properties
+
+| Property Name  | Data Type | Description |
+| -------------- | --------- | ----------- |
+| objectid       | string    | The GraphQL `node_id` of the enterprise-managed user account. |
+| name           | string    | The managed account login. |
+| node_id        | string    | The GraphQL node id. Redundant with objectid. |
+| environment_name | string  | The enterprise slug where the managed account was collected. |
+| environmentid  | string    | The `GH_Enterprise.node_id` where the managed account was collected. |
+| login          | string    | The managed account login. |
+| full_name      | string    | The managed account display name. |
+| url            | string    | The GitHub URL for the managed account wrapper object when returned by GraphQL. |
+| created_at     | string    | When the managed account wrapper object was created. |
+| updated_at     | string    | When the managed account wrapper object was last updated. |
+| github_user_id | string    | The nested traditional GitHub user id when GitHub returns it. |
+| github_username | string   | The nested traditional GitHub username when GitHub returns it. |
+
+Enterprise-managed users are linked to the enterprise with `GH_HasMember` and map to the traditional `GH_User` node with `GH_MapsToUser`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
+    GH_EnterpriseManagedUser[fa:fa-user-lock GH_EnterpriseManagedUser]
+    GH_User[fa:fa-user GH_User]
+
+    GH_Enterprise -.->|GH_HasMember| GH_EnterpriseManagedUser
+    GH_EnterpriseManagedUser -.->|GH_MapsToUser| GH_User
+```

--- a/Documentation/NodeDescriptions/GH_User.md
+++ b/Documentation/NodeDescriptions/GH_User.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_user.png" width="50"/> GH_User
 
-Represents a GitHub user who is a member of one or more GitHub organizations or enterprises. Users are associated with organization roles (Owner or Member), can be assigned to repository roles and team roles, and may also be linked directly to `GH_Enterprise` through `GH_HasMember`.
+Represents a GitHub user who is a member of one or more GitHub organizations or enterprises. Users are associated with organization roles (Owner or Member), can be assigned to repository roles and team roles, and may also be linked directly to `GH_Enterprise` through `GH_HasMember`. In enterprise-managed-user environments, enterprise membership may instead land on a `GH_EnterpriseManagedUser` wrapper that maps back to the underlying `GH_User` via `GH_MapsToUser`.
 
 Created by: `Git-HoundUser`, `Git-HoundEnterpriseUser`
 
@@ -24,6 +24,7 @@ Created by: `Git-HoundUser`, `Git-HoundEnterpriseUser`
 ```mermaid
 flowchart TD
     GH_Enterprise[fa:fa-globe GH_Enterprise]
+    GH_EnterpriseManagedUser[fa:fa-user-lock GH_EnterpriseManagedUser]
     GH_User[fa:fa-user GH_User]
     GH_OrgRole[fa:fa-user-tie GH_OrgRole]
     GH_RepoRole[fa:fa-user-tie GH_RepoRole]
@@ -44,6 +45,7 @@ flowchart TD
 
 
     GH_Enterprise -.->|GH_HasMember| GH_User
+    GH_EnterpriseManagedUser -.->|GH_MapsToUser| GH_User
     GH_User -->|GH_HasRole| GH_OrgRole
     GH_User -->|GH_HasRole| GH_TeamRole
     GH_User -->|GH_HasRole| GH_RepoRole

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -21,6 +21,7 @@
 | ![GH_Branch](Icons/gh_branch.png) | [GH_Branch](NodeDescriptions/GH_Branch.md) | GitHub Branch |
 | ![GH_BranchProtectionRule](Icons/gh_branchprotectionrule.png) | [GH_BranchProtectionRule](NodeDescriptions/GH_BranchProtectionRule.md) | GitHub Branch Protection Rule |
 | ![GH_Enterprise](Icons/gh_enterprise.png) | [GH_Enterprise](NodeDescriptions/GH_Enterprise.md) | GitHub Enterprise |
+| ![GH_EnterpriseManagedUser](Icons/gh_enterprisemanageduser.png) | [GH_EnterpriseManagedUser](NodeDescriptions/GH_EnterpriseManagedUser.md) | GitHub Enterprise Managed User |
 | ![GH_EnterpriseTeam](Icons/gh_enterpriseteam.png) | [GH_EnterpriseTeam](NodeDescriptions/GH_EnterpriseTeam.md) | GitHub Enterprise Team |
 | ![GH_Environment](Icons/gh_environment.png) | [GH_Environment](NodeDescriptions/GH_Environment.md) | GitHub Environment |
 | ![GH_EnvironmentSecret](Icons/gh_environmentsecret.png) | [GH_EnvironmentSecret](NodeDescriptions/GH_EnvironmentSecret.md) | GitHub Environment Secret |

--- a/githound.ps1
+++ b/githound.ps1
@@ -1388,6 +1388,7 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
         members(first: $count, after: $after) {
             edges {
                 node {
+                    __typename
                     ... on User {
                         id
                         databaseId
@@ -1400,6 +1401,9 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
                         id
                         login
                         name
+                        url
+                        createdAt
+                        updatedAt
                         user {
                             id
                             databaseId
@@ -1431,7 +1435,29 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
 
         foreach ($edge in @($result.data.enterprise.members.edges)) {
             $member = $edge.node
+            $isEnterpriseManagedUser = ($member.__typename -eq 'EnterpriseUserAccount')
             $user = if ($member.user) { $member.user } else { $member }
+
+            if ($isEnterpriseManagedUser) {
+                $emuProperties = @{
+                    name             = Normalize-Null $member.login
+                    node_id          = Normalize-Null $member.id
+                    environment_name = Normalize-Null $enterpriseSlug
+                    environmentid    = Normalize-Null $enterpriseNodeId
+                    login            = Normalize-Null $member.login
+                    full_name        = Normalize-Null $member.name
+                    url              = Normalize-Null $member.url
+                    created_at       = Normalize-Null $member.createdAt
+                    updated_at       = Normalize-Null $member.updatedAt
+                    github_user_id   = Normalize-Null $(if ($member.user) { $member.user.id } else { $null })
+                    github_username  = Normalize-Null $(if ($member.user) { $member.user.login } else { $null })
+                    query_enterprises = "MATCH p=(:GH_Enterprise)-[:GH_HasMember]->(:GH_EnterpriseManagedUser {node_id:'$($member.id)'}) RETURN p"
+                    query_mapped_user = "MATCH p=(:GH_EnterpriseManagedUser {node_id:'$($member.id)'})-[:GH_MapsToUser]->(:GH_User) RETURN p"
+                }
+
+                $null = $nodes.Add((New-GitHoundNode -Id $member.id -Kind 'GH_EnterpriseManagedUser' -Properties $emuProperties))
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasMember' -StartId $enterpriseNodeId -EndId $member.id -EndKind 'GH_EnterpriseManagedUser' -Properties @{ traversable = $false }))
+            }
 
             if (-not $user.id) {
                 Write-Warning "Git-HoundEnterpriseUser: Skipping member '$($member.login)' because no user id was returned."
@@ -1452,11 +1478,15 @@ query EnterpriseMembers($slug: String!, $count: Int = 100, $after: String = null
                 query_teams                  = "MATCH p=(:GH_User {node_id:'$($user.id)'})-[:GH_HasRole]->(t:GH_TeamRole)-[:GH_MemberOf*1..4]->(:GH_Team) RETURN p"
                 query_repositories           = "MATCH p=(t:GH_User {node_id:'$($user.id)'})-[:GH_HasRole|GH_HasBaseRole|GH_MemberOf*1..]->(:GH_RepoRole)-[:GH_ReadRepoContents|GH_WriteRepoContents|GH_WriteRepoPullRequests|GH_ManageWebhooks|GH_ManageDeployKeys|GH_PushProtectedBranch|GH_DeleteAlertsCodeScanning|GH_ViewSecretScanningAlerts|GH_RunOrgMigration|GH_BypassBranchProtection|GH_EditRepoProtections]->(:GH_Repository) RETURN p"
                 query_branches               = "MATCH p=(:GH_User {node_id:'$($user.id)'})-[r]->(:GH_BranchProtectionRule)-[:GH_ProtectedBy]->(:GH_Branch) RETURN p"
-                query_enterprises            = "MATCH p=(:GH_Enterprise)-[:GH_HasMember]->(:GH_User {node_id:'$($user.id)'}) RETURN p"
+                query_enterprises            = "MATCH p=(:GH_Enterprise)-[:GH_HasMember]->(:GH_User {node_id:'$($user.id)'}) RETURN p UNION MATCH p=(:GH_Enterprise)-[:GH_HasMember]->(:GH_EnterpriseManagedUser)-[:GH_MapsToUser]->(:GH_User {node_id:'$($user.id)'}) RETURN p"
             }
 
             $null = $nodes.Add((New-GitHoundNode -Id $user.id -Kind 'GH_User' -Properties $properties))
-            $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasMember' -StartId $enterpriseNodeId -EndId $user.id -Properties @{ traversable = $false }))
+            if ($isEnterpriseManagedUser) {
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_MapsToUser' -StartId $member.id -StartKind 'GH_EnterpriseManagedUser' -EndId $user.id -Properties @{ traversable = $false }))
+            } else {
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasMember' -StartId $enterpriseNodeId -EndId $user.id -Properties @{ traversable = $false }))
+            }
         }
 
         $Variables['after'] = $result.data.enterprise.members.pageInfo.endCursor

--- a/schema.json
+++ b/schema.json
@@ -31,6 +31,14 @@
       "color": "#FF8E40"
     },
     {
+      "name": "GH_EnterpriseManagedUser",
+      "display_name": "GitHub Enterprise Managed User",
+      "description": "An enterprise-managed GitHub account wrapper returned as EnterpriseUserAccount in enterprise member collection",
+      "is_display_kind": true,
+      "icon": "user-lock",
+      "color": "#F2C14E"
+    },
+    {
       "name": "GH_EnterpriseTeam",
       "display_name": "GitHub Enterprise Team",
       "description": "An enterprise-level team that can be assigned into one or more organizations and projected as organization teams",


### PR DESCRIPTION
- update enterprise member collection to handle both GraphQL EnterpriseMember shapes:
  - traditional User
  - EnterpriseUserAccount for enterprise managed users
- create GH_EnterpriseManagedUser nodes when EnterpriseUserAccount objects are returned
- continue creating the corresponding GH_User node for the underlying GitHub principal
- add GH_HasMember from GH_Enterprise to GH_EnterpriseManagedUser for managed-account memberships
- add GH_MapsToUser from GH_EnterpriseManagedUser to GH_User to preserve the relationship between the managed account wrapper and the underlying GitHub user
- keep direct GH_HasMember from GH_Enterprise to GH_User only for the traditional non-EMU case

- add GH_EnterpriseManagedUser to schema.json with icon and color metadata
- add documentation for GH_EnterpriseManagedUser
- update GH_User, GH_Enterprise, GH_HasMember, GH_MapsToUser, and Schema documentation to describe EMU-aware enterprise membership modeling

- make GH_User enterprise query helpers EMU-aware by allowing enterprise membership to resolve through GH_EnterpriseManagedUser -> GH_MapsToUser -> GH_User
- intentionally keep SCIM_Provisioned targeting GH_ExternalIdentity for now because current SCIM data does not provide a clean direct correlation to GH_EnterpriseManagedUser