### PR TITLE
Add enterprise role collection and enterprise admin role modeling

### DIFF
--- a/Documentation/EdgeDescriptions/GH_HasRole.md
+++ b/Documentation/EdgeDescriptions/GH_HasRole.md
@@ -2,23 +2,26 @@
 
 ## Edge Schema
 
-- Source: [GH_User](../NodeDescriptions/GH_User.md), [GH_Team](../NodeDescriptions/GH_Team.md)
-- Destination: [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md)
+- Source: [GH_User](../NodeDescriptions/GH_User.md), [GH_Team](../NodeDescriptions/GH_Team.md), [GH_EnterpriseTeam](../NodeDescriptions/GH_EnterpriseTeam.md)
+- Destination: [GH_OrgRole](../NodeDescriptions/GH_OrgRole.md), [GH_RepoRole](../NodeDescriptions/GH_RepoRole.md), [GH_TeamRole](../NodeDescriptions/GH_TeamRole.md), [GH_EnterpriseRole](../NodeDescriptions/GH_EnterpriseRole.md)
 
 ## General Information
 
-The traversable [GH_HasRole](GH_HasRole.md) edge represents the assignment of a user or team to a specific role within the organization, repository, or team. This is the primary edge for connecting identities to their permissions and serves as the foundation of all access paths in the GitHub permission model. It is created by `Git-HoundUser` (for org roles), `Git-HoundRepositoryRole` (for repo roles), and `Git-HoundTeam` (for team roles). Because role assignment is the starting point for determining what a principal can do, this edge is traversable and critical for attack path analysis.
+The traversable [GH_HasRole](GH_HasRole.md) edge represents the assignment of a user or team to a specific role within the organization, repository, team, or enterprise. This is the primary edge for connecting identities to their permissions and serves as the foundation of all access paths in the GitHub permission model. It is created by `Git-HoundUser` (for org roles), `Git-HoundRepositoryRole` (for repo roles), `Git-HoundTeam` (for team roles), and `Git-HoundEnterpriseRole` (for enterprise roles). Because role assignment is the starting point for determining what a principal can do, this edge is traversable and critical for attack path analysis.
 
 ```mermaid
 graph LR
     user1("GH_User alice")
     user2("GH_User bob")
     team1("GH_Team security-team")
+    entTeam("GH_EnterpriseTeam corp-security")
     orgRole("GH_OrgRole SpecterOps\\Owners")
     repoRole("GH_RepoRole GitHound\\write")
     teamRole("GH_TeamRole security-team\\maintainer")
+    entRole("GH_EnterpriseRole k-nexus-global\\enterprise_security_manager")
     user1 -- GH_HasRole --> orgRole
     user2 -- GH_HasRole --> repoRole
     team1 -- GH_HasRole --> repoRole
     user1 -- GH_HasRole --> teamRole
+    entTeam -- GH_HasRole --> entRole
 ```

--- a/Documentation/NodeDescriptions/GH_Enterprise.md
+++ b/Documentation/NodeDescriptions/GH_Enterprise.md
@@ -26,7 +26,7 @@ Created by: `Git-HoundEnterprise`
 | security_contact_email| string    | The enterprise security contact email, when available.                                          |
 | viewer_is_admin       | boolean   | Whether the authenticated principal is an enterprise admin.                                     |
 
-Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes in traditional-account environments, and to `GH_EnterpriseManagedUser` nodes in enterprise-managed-user environments. Enterprise-managed users then map back to `GH_User` with `GH_MapsToUser`. Enterprise team collection adds `GH_EnterpriseTeam` nodes, links them with `GH_Contains`, and models organization assignment separately with `GH_AssignedTo`.
+Enterprise collection currently emits lightweight `GH_Organization` stub nodes for member organizations and links them with `GH_Contains`. Those organization nodes are intended to be enriched later by full organization collection. Enterprise user collection adds `GH_HasMember` edges from the enterprise to discovered `GH_User` nodes in traditional-account environments, and to `GH_EnterpriseManagedUser` nodes in enterprise-managed-user environments. Enterprise-managed users then map back to `GH_User` with `GH_MapsToUser`. Enterprise team collection adds `GH_EnterpriseTeam` nodes, links them with `GH_Contains`, and models organization assignment separately with `GH_AssignedTo`. Enterprise role collection adds `GH_EnterpriseRole` nodes, links them with `GH_Contains`, captures direct user and enterprise-team role assignments with `GH_HasRole`, and uses a default `owners` role to represent enterprise admins discovered through `ownerInfo.admins`.
 
 ## Diagram
 
@@ -35,12 +35,16 @@ flowchart TD
     GH_Enterprise[fa:fa-globe GH_Enterprise]
     GH_Organization[fa:fa-building GH_Organization]
     GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
+    GH_EnterpriseRole[fa:fa-user-tie GH_EnterpriseRole]
     GH_EnterpriseManagedUser[fa:fa-user-lock GH_EnterpriseManagedUser]
     GH_User[fa:fa-user GH_User]
 
     GH_Enterprise -.->|GH_Contains| GH_Organization
     GH_Enterprise -.->|GH_Contains| GH_EnterpriseTeam
+    GH_Enterprise -.->|GH_Contains| GH_EnterpriseRole
     GH_Enterprise -.->|GH_HasMember| GH_User
     GH_Enterprise -.->|GH_HasMember| GH_EnterpriseManagedUser
     GH_EnterpriseManagedUser -.->|GH_MapsToUser| GH_User
+    GH_User -->|GH_HasRole| GH_EnterpriseRole
+    GH_EnterpriseTeam -->|GH_HasRole| GH_EnterpriseRole
 ```

--- a/Documentation/NodeDescriptions/GH_EnterpriseRole.md
+++ b/Documentation/NodeDescriptions/GH_EnterpriseRole.md
@@ -1,0 +1,40 @@
+# <img src="../Icons/gh_enterpriserole.png" width="50"/> GH_EnterpriseRole
+
+Represents an enterprise-level role within a GitHub enterprise. Enterprise roles can be assigned directly to users or to `GH_EnterpriseTeam` nodes, and they preserve the raw permission strings returned by GitHub on the node itself. This keeps the first-pass model lightweight while still surfacing the real enterprise authorization data we collected. GitHound currently creates both REST-enumerated enterprise roles and a default `owners` role populated from `ownerInfo.admins` when PAT-backed enterprise admin data is available.
+
+Created by: `Git-HoundEnterpriseRole`
+
+## Properties
+
+| Property Name    | Data Type | Description |
+| ---------------- | --------- | ----------- |
+| objectid         | string    | Synthetic ID derived from the enterprise node ID and the GitHub enterprise role ID. |
+| name             | string    | Fully qualified role name, for example `k-nexus-global/enterprise_security_manager`. |
+| node_id          | string    | Same as objectid. |
+| environment_name | string    | The enterprise slug. |
+| environmentid    | string    | The enterprise GraphQL node ID. |
+| github_role_id   | string    | The raw enterprise role ID returned by the REST API. |
+| short_name       | string    | The short display name of the role. |
+| description      | string    | The role description returned by GitHub. |
+| source           | string    | The origin of the role, such as `Predefined` or `Default`. |
+| type             | string    | `default` for predefined/default roles or `custom` for custom enterprise roles. |
+| created_at       | datetime  | When the role was created. |
+| updated_at       | datetime  | When the role was last updated. |
+| permissions      | string[]  | Raw enterprise permission strings returned by GitHub for the role. |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    GH_Enterprise[fa:fa-globe GH_Enterprise]
+    GH_EnterpriseRole[fa:fa-user-tie GH_EnterpriseRole]
+    GH_User[fa:fa-user GH_User]
+    GH_EnterpriseTeam[fa:fa-users-between-lines GH_EnterpriseTeam]
+    GH_TeamRole[fa:fa-user-tie GH_TeamRole]
+
+    GH_Enterprise -.->|GH_Contains| GH_EnterpriseRole
+    GH_User -->|GH_HasRole| GH_EnterpriseRole
+    GH_EnterpriseTeam -->|GH_HasRole| GH_EnterpriseRole
+    GH_User -->|GH_HasRole| GH_TeamRole
+    GH_TeamRole -->|GH_MemberOf| GH_EnterpriseTeam
+```

--- a/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
+++ b/Documentation/NodeDescriptions/GH_EnterpriseTeam.md
@@ -1,6 +1,6 @@
 # <img src="../Icons/gh_enterpriseteam.png" width="50"/> GH_EnterpriseTeam
 
-Represents a GitHub enterprise-level team. Enterprise teams are assigned into organizations from the enterprise layer and can map to organization-scoped `ent:` teams that then carry repository permissions.
+Represents a GitHub enterprise-level team. Enterprise teams are assigned into organizations from the enterprise layer, can be assigned enterprise roles directly, and can map to organization-scoped `ent:` teams that then carry repository permissions.
 
 Created by: `Git-HoundEnterpriseTeam`
 
@@ -21,7 +21,7 @@ Created by: `Git-HoundEnterpriseTeam`
 | created_at             | string    | When the enterprise team was created. |
 | updated_at             | string    | When the enterprise team was last updated. |
 
-Enterprise team membership is represented through a synthetic `GH_TeamRole` node (`members`) linked with `GH_MemberOf`. Organization assignment is represented with `GH_AssignedTo`, and the enterprise team is linked to org-visible `ent:` teams with a property-matched `GH_MemberOf` edge once those organization teams exist in the graph.
+Enterprise team membership is represented through a synthetic `GH_TeamRole` node (`members`) linked with `GH_MemberOf`. Organization assignment is represented with `GH_AssignedTo`, enterprise role assignment is represented with `GH_HasRole`, and the enterprise team is linked to org-visible `ent:` teams with a property-matched `GH_MemberOf` edge once those organization teams exist in the graph.
 
 When GitHub exposes a `group_id` on the enterprise team, GitHound can also tie the GitHub enterprise team model back to the shared SCIM schema by correlating `SCIM_Group` to `GH_EnterpriseTeam` with `SCIM_Provisioned`. That gives us a native bridge from SCIM-provisioned groups into the GitHub enterprise team model without relying on provider-specific assumptions.
 
@@ -34,11 +34,13 @@ flowchart TD
     GH_Organization[fa:fa-building GH_Organization]
     GH_Team[fa:fa-user-group GH_Team]
     GH_TeamRole[fa:fa-user-tie GH_TeamRole]
+    GH_EnterpriseRole[fa:fa-user-tie GH_EnterpriseRole]
     GH_User[fa:fa-user GH_User]
 
     GH_Enterprise -.->|GH_Contains| GH_EnterpriseTeam
     GH_EnterpriseTeam -.->|GH_AssignedTo| GH_Organization
     GH_TeamRole -->|GH_MemberOf| GH_EnterpriseTeam
+    GH_EnterpriseTeam -->|GH_HasRole| GH_EnterpriseRole
     GH_EnterpriseTeam -->|GH_MemberOf| GH_Team
     GH_User -->|GH_HasRole| GH_TeamRole
 ```

--- a/Documentation/Queries.md
+++ b/Documentation/Queries.md
@@ -210,6 +210,30 @@ LIMIT 1000
 
 This query is useful for validating enterprise member discovery and Enterprise Managed Users handling.
 
+## Enterprise Admins
+
+Returns enterprise admins through the default `owners` enterprise role.
+
+```cypher
+MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_EnterpriseRole {short_name:'owners'})
+RETURN p
+LIMIT 1000
+```
+
+This query is useful for validating the `ownerInfo.admins` enterprise admin path.
+
+## Enterprise Role Assignments
+
+Returns enterprise roles and the users or enterprise teams assigned to them.
+
+```cypher
+MATCH p=(principal)-[:GH_HasRole]->(role:GH_EnterpriseRole)
+RETURN p
+LIMIT 1000
+```
+
+This query is useful for validating enterprise authorization modeling before expanding enterprise-role permissions further.
+
 ### Enterprise Team Assignments and Projections
 
 Returns enterprise teams, the organizations they are assigned to, and any projected `ent:` organization teams linked back to them.

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -22,6 +22,7 @@
 | ![GH_BranchProtectionRule](Icons/gh_branchprotectionrule.png) | [GH_BranchProtectionRule](NodeDescriptions/GH_BranchProtectionRule.md) | GitHub Branch Protection Rule |
 | ![GH_Enterprise](Icons/gh_enterprise.png) | [GH_Enterprise](NodeDescriptions/GH_Enterprise.md) | GitHub Enterprise |
 | ![GH_EnterpriseManagedUser](Icons/gh_enterprisemanageduser.png) | [GH_EnterpriseManagedUser](NodeDescriptions/GH_EnterpriseManagedUser.md) | GitHub Enterprise Managed User |
+| ![GH_EnterpriseRole](Icons/gh_enterpriserole.png) | [GH_EnterpriseRole](NodeDescriptions/GH_EnterpriseRole.md) | GitHub Enterprise Role |
 | ![GH_EnterpriseTeam](Icons/gh_enterpriseteam.png) | [GH_EnterpriseTeam](NodeDescriptions/GH_EnterpriseTeam.md) | GitHub Enterprise Team |
 | ![GH_Environment](Icons/gh_environment.png) | [GH_Environment](NodeDescriptions/GH_Environment.md) | GitHub Environment |
 | ![GH_EnvironmentSecret](Icons/gh_environmentsecret.png) | [GH_EnvironmentSecret](NodeDescriptions/GH_EnvironmentSecret.md) | GitHub Environment Secret |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ Enterprise team collection through `Git-HoundEnterpriseTeam` adds:
 - `GH_MemberOf` edges from enterprise teams to org-visible `ent:` `GH_Team` nodes using property matching
 - enterprise-team `members` roles and `GH_HasRole` edges from users to those roles
 
+Enterprise role collection through `Git-HoundEnterpriseRole` adds:
+
+- `GH_EnterpriseRole`
+- `GH_Contains` edges from the enterprise to those roles
+- `GH_HasRole` edges from directly assigned users and enterprise teams
+- a default `owners` role populated from `enterprise.ownerInfo.admins` when PAT-backed enterprise admin data is available
+
+For now, raw enterprise permission strings are preserved on the `GH_EnterpriseRole` node in its `permissions` property rather than being expanded into dedicated permission edges.
+
 Enterprise SCIM collection currently adds:
 
 - `SCIM_User`

--- a/githound.ps1
+++ b/githound.ps1
@@ -881,6 +881,19 @@ function Get-GitHoundEnterpriseTeamNodeId
     "GH_EnterpriseTeam_${EnterpriseId}_${TeamId}"
 }
 
+function Get-GitHoundEnterpriseRoleNodeId
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EnterpriseId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RoleId
+    )
+
+    "GH_EnterpriseRole_${EnterpriseId}_${RoleId}"
+}
+
 function Get-GitHoundOrganizationTeamNodeId
 {
     param(
@@ -1634,6 +1647,205 @@ function Git-HoundEnterpriseTeam
     }
 
     Write-Host "[+] Git-HoundEnterpriseTeam complete. $($nodes.Count) nodes, $($edges.Count) edges."
+
+    [PSCustomObject]@{
+        Nodes = $nodes
+        Edges = $edges
+    }
+}
+
+function Git-HoundEnterpriseRole
+{
+    <#
+    .SYNOPSIS
+        Retrieves enterprise roles and their direct user/team assignments.
+
+    .DESCRIPTION
+        This function queries the enterprise roles REST API to enumerate enterprise roles and
+        model their assignments without exploding each permission into a separate edge. The
+        raw permission strings returned by GitHub are preserved on the GH_EnterpriseRole node
+        so we can inspect the real data before deciding how opinionated the permission model
+        should become.
+
+        API Reference:
+        - List enterprise roles: GET /enterprises/{enterprise}/enterprise-roles
+        - List users assigned to role: GET /enterprises/{enterprise}/enterprise-roles/{role_id}/users
+        - List teams assigned to role: GET /enterprises/{enterprise}/enterprise-roles/{role_id}/teams
+
+    .PARAMETER Session
+        A GitHound.Session object with EnterpriseName set.
+
+    .PARAMETER Enterprise
+        The GH_Enterprise node object (from Git-HoundEnterprise output).
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position = 0, Mandatory = $true)]
+        [PSTypeName('GitHound.Session')]
+        $Session,
+
+        [Parameter(Position = 1, Mandatory = $true)]
+        [PSObject]
+        $Enterprise
+    )
+
+    if (-not $Session.EnterpriseName) {
+        throw "Git-HoundEnterpriseRole requires Session.EnterpriseName to be set."
+    }
+
+    $nodes = New-Object System.Collections.ArrayList
+    $edges = New-Object System.Collections.ArrayList
+
+    $enterpriseSlug = $Session.EnterpriseName
+    $enterpriseNodeId = Normalize-Null $(if ($Enterprise.id) { $Enterprise.id } elseif ($Enterprise.properties.node_id) { $Enterprise.properties.node_id } else { $null })
+
+    if (-not $enterpriseNodeId) {
+        throw "Git-HoundEnterpriseRole requires a GH_Enterprise node object with an id or properties.node_id."
+    }
+
+    Write-Host "[*] Git-HoundEnterpriseRole: Collecting enterprise roles for '$enterpriseSlug'"
+
+    try {
+        $rolesResult = Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/enterprise-roles" -ErrorMode Stop
+        $roles = @($rolesResult.roles)
+    }
+    catch {
+        $errorInfo = Get-GitHoundRestErrorInfo -ErrorRecord $_ -Path "enterprises/$enterpriseSlug/enterprise-roles"
+        Write-GitHoundRestSkipWarning -Target $enterpriseSlug -Feature "enterprise roles" -ErrorInfo $errorInfo
+        $roles = @()
+    }
+
+    if ($Session.HasPersonalAccessToken) {
+        $ownersRoleId = Get-GitHoundEnterpriseRoleNodeId -EnterpriseId $enterpriseNodeId -RoleId 'owners'
+        $ownersRoleProps = [pscustomobject]@{
+            name                   = Normalize-Null "$enterpriseSlug/owners"
+            node_id                = Normalize-Null $ownersRoleId
+            environment_name       = Normalize-Null $enterpriseSlug
+            environmentid          = Normalize-Null $enterpriseNodeId
+            github_role_id         = Normalize-Null 'owners'
+            short_name             = Normalize-Null 'owners'
+            description            = Normalize-Null 'Enterprise administrators discovered from ownerInfo.admins'
+            source                 = Normalize-Null 'Default'
+            type                   = Normalize-Null 'default'
+            created_at             = Normalize-Null $null
+            updated_at             = Normalize-Null $null
+            permissions            = @()
+            query_enterprise       = "MATCH p=(:GH_Enterprise {node_id:'$enterpriseNodeId'})-[:GH_Contains]->(:GH_EnterpriseRole {node_id:'$ownersRoleId'}) RETURN p"
+            query_explicit_members = "MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_EnterpriseRole {node_id:'$ownersRoleId'}) RETURN p"
+        }
+
+        $null = $nodes.Add((New-GitHoundNode -Id $ownersRoleId -Kind 'GH_EnterpriseRole', 'GH_Role' -Properties $ownersRoleProps))
+        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $enterpriseNodeId -EndId $ownersRoleId -Properties @{ traversable = $false }))
+
+        Write-Host "[*] Git-HoundEnterpriseRole: Collecting enterprise admins (ownerInfo.admins)"
+
+        $adminsQuery = @'
+query EnterpriseAdmins($slug: String!, $count: Int = 100, $after: String = null) {
+    enterprise(slug: $slug) {
+        ownerInfo {
+            admins(first: $count, after: $after) {
+                edges {
+                    node {
+                        id
+                        login
+                    }
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+    }
+}
+'@
+
+        $adminVariables = @{
+            slug = $enterpriseSlug
+            count = 100
+            after = $null
+        }
+
+        try {
+            do {
+                $adminResult = Invoke-GitHubGraphQL -Session $Session -Headers (Get-GitHoundAuthHeaders -Session $Session -AuthType PAT) -Query $adminsQuery -Variables $adminVariables
+                $adminsPage = $adminResult.data.enterprise.ownerInfo.admins
+
+                foreach ($adminEdge in @($adminsPage.edges)) {
+                    $adminNode = $adminEdge.node
+                    $adminUserId = $adminNode.id
+                    if ($adminUserId) {
+                        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $adminUserId -EndId $ownersRoleId -Properties @{ traversable = $true }))
+                    }
+                }
+
+                $adminVariables['after'] = $adminsPage.pageInfo.endCursor
+            }
+            while ($adminsPage.pageInfo.hasNextPage)
+        }
+        catch {
+            Write-Warning "Git-HoundEnterpriseRole: Failed to collect enterprise admins: $_"
+        }
+    }
+
+    foreach ($role in $roles) {
+        $roleId = Get-GitHoundEnterpriseRoleNodeId -EnterpriseId $enterpriseNodeId -RoleId $role.id
+        $permissions = @($role.permissions | Where-Object { $_ })
+
+        $properties = [pscustomobject]@{
+            name                    = Normalize-Null "$enterpriseSlug/$($role.name)"
+            node_id                 = Normalize-Null $roleId
+            environment_name        = Normalize-Null $enterpriseSlug
+            environmentid           = Normalize-Null $enterpriseNodeId
+            github_role_id          = Normalize-Null $role.id
+            short_name              = Normalize-Null $role.name
+            description             = Normalize-Null $role.description
+            source                  = Normalize-Null $role.source
+            type                    = Normalize-Null $(if ($role.source -eq 'Predefined') { 'default' } else { 'custom' })
+            created_at              = Normalize-Null $role.created_at
+            updated_at              = Normalize-Null $role.updated_at
+            permissions             = $permissions
+            query_enterprise        = "MATCH p=(:GH_Enterprise {node_id:'$enterpriseNodeId'})-[:GH_Contains]->(:GH_EnterpriseRole {node_id:'$roleId'}) RETURN p"
+            query_explicit_members  = "MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_EnterpriseRole {node_id:'$roleId'}) RETURN p"
+            query_team_members      = "MATCH p=(:GH_User)-[:GH_HasRole]->(:GH_TeamRole)-[:GH_MemberOf]->(:GH_EnterpriseTeam)-[:GH_HasRole]->(:GH_EnterpriseRole {node_id:'$roleId'}) RETURN p"
+        }
+
+        $null = $nodes.Add((New-GitHoundNode -Id $roleId -Kind 'GH_EnterpriseRole', 'GH_Role' -Properties $properties))
+        $null = $edges.Add((New-GitHoundEdge -Kind 'GH_Contains' -StartId $enterpriseNodeId -EndId $roleId -Properties @{ traversable = $false }))
+
+        try {
+            $roleUsers = @(Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/enterprise-roles/$($role.id)/users" -ErrorMode Stop)
+        }
+        catch {
+            $errorInfo = Get-GitHoundRestErrorInfo -ErrorRecord $_ -Path "enterprises/$enterpriseSlug/enterprise-roles/$($role.id)/users"
+            Write-GitHoundRestSkipWarning -Target "$enterpriseSlug/$($role.name)" -Feature "enterprise role users" -ErrorInfo $errorInfo
+            $roleUsers = @()
+        }
+
+        foreach ($user in $roleUsers) {
+            if ($user.assignment -eq 'direct' -and $user.node_id) {
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $user.node_id -EndId $roleId -Properties @{ traversable = $true }))
+            }
+        }
+
+        try {
+            $roleTeams = @(Invoke-GithubRestMethod -Session $Session -Path "enterprises/$enterpriseSlug/enterprise-roles/$($role.id)/teams" -ErrorMode Stop)
+        }
+        catch {
+            $errorInfo = Get-GitHoundRestErrorInfo -ErrorRecord $_ -Path "enterprises/$enterpriseSlug/enterprise-roles/$($role.id)/teams"
+            Write-GitHoundRestSkipWarning -Target "$enterpriseSlug/$($role.name)" -Feature "enterprise role teams" -ErrorInfo $errorInfo
+            $roleTeams = @()
+        }
+
+        foreach ($team in $roleTeams) {
+            if ($team.id) {
+                $teamId = Get-GitHoundEnterpriseTeamNodeId -EnterpriseId $enterpriseNodeId -TeamId $team.id
+                $null = $edges.Add((New-GitHoundEdge -Kind 'GH_HasRole' -StartId $teamId -StartKind 'GH_EnterpriseTeam' -EndId $roleId -Properties @{ traversable = $true }))
+            }
+        }
+    }
+
+    Write-Host "[+] Git-HoundEnterpriseRole complete. $($nodes.Count) nodes, $($edges.Count) edges."
 
     [PSCustomObject]@{
         Nodes = $nodes
@@ -9255,6 +9467,7 @@ function Invoke-GitHoundEnterprise
         - GH_Enterprise and org containment (Git-HoundEnterprise)
         - enterprise members (Git-HoundEnterpriseUser)
         - enterprise teams (Git-HoundEnterpriseTeam)
+        - enterprise roles (Git-HoundEnterpriseRole)
         - enterprise SCIM users (Git-HoundEnterpriseScimUser, when PAT-backed)
         - enterprise SAML provider and external identities (Git-HoundEnterpriseSamlProvider, when PAT-backed)
 
@@ -9389,7 +9602,21 @@ function Invoke-GitHoundEnterprise
     if($enterpriseTeams.Nodes) { $nodes.AddRange(@($enterpriseTeams.Nodes)) }
     if($enterpriseTeams.Edges) { $edges.AddRange(@($enterpriseTeams.Edges)) }
 
-    # ── Step 4: Enterprise SCIM Users ────────────────────────────────────
+    # ── Step 4: Enterprise Roles ─────────────────────────────────────────
+    $stepFile = Join-Path $CheckpointPath "githound_EnterpriseRole_$entId.json"
+    if ($Resume -and (Test-Path $stepFile)) {
+        Write-Host "[*] Resuming: Loaded Enterprise Roles from githound_EnterpriseRole_$entId.json"
+        $enterpriseRoles = Import-GitHoundStepOutput -FilePath $stepFile
+    } else {
+        Write-Host "[*] Enumerating Enterprise Roles"
+        $enterpriseRoles = Git-HoundEnterpriseRole -Session $Session -Enterprise $enterprise.Nodes[0]
+        Export-GitHoundStepOutput -StepResult $enterpriseRoles -FilePath $stepFile
+        Write-Host "[+] Saved: githound_EnterpriseRole_$entId.json"
+    }
+    if($enterpriseRoles.Nodes) { $nodes.AddRange(@($enterpriseRoles.Nodes)) }
+    if($enterpriseRoles.Edges) { $edges.AddRange(@($enterpriseRoles.Edges)) }
+
+    # ── Step 5: Enterprise SCIM Users ────────────────────────────────────
     $enterpriseScimUsers = [PSCustomObject]@{
         Nodes = @()
         Edges = @()
@@ -9415,7 +9642,7 @@ function Invoke-GitHoundEnterprise
         Write-Host "[*] Skipping Enterprise SCIM Users (session does not contain a PAT)"
     }
 
-    # ── Step 5: Enterprise SCIM Groups ───────────────────────────────────
+    # ── Step 6: Enterprise SCIM Groups ───────────────────────────────────
     if ($Session.HasPersonalAccessToken) {
         $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSCIMGroup_$entId.json"
         if ($Resume -and (Test-Path $stepFile)) {
@@ -9432,7 +9659,7 @@ function Invoke-GitHoundEnterprise
         Write-Host "[*] Skipping Enterprise SCIM Groups (session does not contain a PAT)"
     }
 
-    # ── Step 6: Enterprise SAML (separate output) ────────────────────────
+    # ── Step 7: Enterprise SAML (separate output) ────────────────────────
     if ($Session.HasPersonalAccessToken) {
         $stepFile = Join-Path $CheckpointPath "githound_EnterpriseSaml_$entId.json"
         if ($Resume -and (Test-Path $stepFile)) {
@@ -9500,6 +9727,7 @@ function Invoke-GitHoundEnterprise
                 "githound_Enterprise_$entId.json",
                 "githound_EnterpriseUser_$entId.json",
                 "githound_EnterpriseTeam_$entId.json",
+                "githound_EnterpriseRole_$entId.json",
                 "githound_EnterpriseSCIMUser_$entId.json",
                 "githound_EnterpriseSCIMGroup_$entId.json",
                 "githound_EnterpriseSaml_$entId.json"
@@ -9569,6 +9797,7 @@ function Invoke-GitHoundEnterprise
             "githound_Enterprise_$entId.json",
             "githound_EnterpriseUser_$entId.json",
             "githound_EnterpriseTeam_$entId.json",
+            "githound_EnterpriseRole_$entId.json",
             "githound_EnterpriseSCIMUser_$entId.json",
             "githound_EnterpriseSCIMGroup_$entId.json",
             "githound_EnterpriseSaml_$entId.json"

--- a/schema.json
+++ b/schema.json
@@ -47,6 +47,14 @@
       "color": "#7C3AED"
     },
     {
+      "name": "GH_EnterpriseRole",
+      "display_name": "GitHub Enterprise Role",
+      "description": "An enterprise-level role that can be assigned to users and enterprise teams",
+      "is_display_kind": true,
+      "icon": "user-tie",
+      "color": "#8FD3FF"
+    },
+    {
       "name": "GH_Team",
       "display_name": "GitHub Team",
       "description": "A team within an organization, grouping users for shared access and collaboration",


### PR DESCRIPTION
- add GH_EnterpriseRole as a first-class node kind in the GitHound schema
- add Git-HoundEnterpriseRole to collect enterprise roles from the enterprise roles REST API
- create GH_EnterpriseRole nodes for enterprise roles and preserve raw GitHub permission strings on the node in a permissions property
- add GH_Contains from GH_Enterprise to GH_EnterpriseRole
- add GH_HasRole assignments from directly assigned GH_User principals to GH_EnterpriseRole
- add GH_HasRole assignments from GH_EnterpriseTeam to GH_EnterpriseRole using the current enterprise team identity model

- add a default owners enterprise role populated from enterprise.ownerInfo.admins when PAT-backed enterprise admin data is available
- model enterprise admins as GH_User -[:GH_HasRole]-> GH_EnterpriseRole {short_name:'owners'}
- move enterprise admin enumeration into Git-HoundEnterpriseRole so enterprise user collection remains focused on identity and membership

- integrate enterprise roles into Invoke-GitHoundEnterprise
- add enterprise role step output as githound_EnterpriseRole_<entId>.json
- include enterprise role data in the consolidated githound_<entId>.json enterprise graph
- include enterprise role step files in enterprise cleanupintermediates handling

- update enterprise role query helpers so team-member expansion follows the current enterprise team model:
  - GH_User -> GH_TeamRole -> GH_EnterpriseTeam -> GH_HasRole -> GH_EnterpriseRole

- add documentation for GH_EnterpriseRole
- update GH_HasRole and GH_Enterprise documentation to include enterprise role modeling
- update README with enterprise role collection details and the default owners role
- add Queries documentation for enterprise admins and enterprise role assignments