### PR TITLE
Skip empty SAML and SCIM sidecar outputs

### DIFF
--- a/Documentation/SCIMSamlProviderComparison.md
+++ b/Documentation/SCIMSamlProviderComparison.md
@@ -1,0 +1,107 @@
+# SCIM / SAML Provider Comparison
+
+This note captures the current differences between two useful reference outputs:
+
+- Enterprise-scoped Okta:
+  - `output/k-nexusglobal/githound_saml_E_kgDOAAiv9g.json`
+  - `output/k-nexusglobal/githound_scim_E_kgDOAAiv9g.json`
+- Organization-scoped Entra:
+  - `output/specterops-pre-gearset/githound_saml_MDEyOk9yZ2FuaXphdGlvbjI1NDA2NTYw.json`
+  - `output/specterops-pre-gearset/githound_scim_MDEyOk9yZ2FuaXphdGlvbjI1NDA2NTYw.json`
+
+The main goal is to understand what upstream IdP hybrid edges GitHound can justify today and what additional provider-specific work would be needed.
+
+## Scope Differences
+
+- Enterprise SCIM includes both `SCIM_User` and `SCIM_Group`.
+- Organization SCIM currently includes only `SCIM_User`.
+- Enterprise SCIM therefore supports:
+  - `SCIM_MemberOf`
+  - `SCIM_Group -> GH_EnterpriseTeam` via `SCIM_Provisioned`
+- Organization SCIM does not currently have a GitHub-native group layer to correlate against.
+- This is a GitHub product limitation, not just a current GitHound omission: organization-level SCIM does not expose a Group -> Team mapping comparable to the enterprise `SCIM_Group -> GH_EnterpriseTeam` path.
+
+## Common Ground
+
+Both outputs support the provider-agnostic GitHub bridge:
+
+- `SCIM_User -> GH_ExternalIdentity`
+
+That correlation is based on:
+
+- `SCIM_User.id -> GH_ExternalIdentity.guid`
+- `SCIM_User.userName -> GH_ExternalIdentity.scim_identity_username`
+
+This is the stable shared layer and should remain provider-agnostic.
+
+## Okta Enterprise Pattern
+
+The enterprise Okta SAML provider exposes:
+
+- `issuer = http://www.okta.com/...`
+- `sso_url = https://<tenant>.oktapreview.com/...`
+- `foreign_environmentid = <okta domain>`
+
+The enterprise Okta SCIM users expose:
+
+- `externalId = 00u...`
+
+That gives GitHound a clean upstream-user correlation:
+
+- `Okta_User -> SCIM_User`
+  - `Okta_User.id = SCIM_User.externalId`
+
+Enterprise SCIM groups expose:
+
+- `SCIM_Group.externalId = <group name>`
+
+Combined with the Okta SAML provider tenant, that supports:
+
+- `Okta_Group -> SCIM_Group`
+  - `Okta_Group.name = SCIM_Group.externalId`
+  - `Okta_Group.oktaDomain = GH_SamlIdentityProvider.foreign_environmentid`
+
+This is why `Resolve-GitHoundScimIdpCorrelations` currently produces upstream hybrid edges for Okta.
+
+## Entra Organization Pattern
+
+The organization Entra SAML provider exposes:
+
+- `issuer = https://sts.windows.net/<tenant-guid>/`
+- `sso_url = https://login.microsoftonline.com/<tenant-guid>/saml2`
+- `foreign_environmentid = <tenant guid>`
+
+The organization Entra SCIM users expose:
+
+- `externalId = <GUID>`
+
+That supports an upstream-user hybrid edge of the form:
+
+- `AZUser -> SCIM_User`
+  - keyed by the Entra object id / GUID
+
+GitHound can derive that edge from the collected `GH_SamlIdentityProvider` context by matching:
+
+- `AZUser.objectid = SCIM_User.externalId`
+- `AZUser.tenantid = GH_SamlIdentityProvider.foreign_environmentid`
+
+## Current Recommendation
+
+Keep the current split:
+
+- Always emit the provider-agnostic bridge:
+  - `SCIM_User -> GH_ExternalIdentity`
+- Emit provider-aware upstream hybrid edges only when the SAML provider shape gives us a strong match strategy.
+
+That means today:
+
+- supported:
+  - `AZUser -> SCIM_User`
+  - `Okta_User -> SCIM_User`
+  - `Okta_Group -> SCIM_Group`
+- not yet implemented:
+  - any Entra group correlation
+
+## Current Boundary
+
+Entra support should remain organization/user focused until we have a validated enterprise Entra example with group semantics comparable to the Okta enterprise reference.

--- a/githound.ps1
+++ b/githound.ps1
@@ -1278,6 +1278,28 @@ function Get-GitHoundOktaGroupPropertyMatchers
     )
 }
 
+function Get-GitHoundAzureUserPropertyMatchers
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ObjectId,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TenantId
+    )
+
+    $matchers = @(
+        (New-BHOGPropertyMatcher -Key 'objectid' -Value $ObjectId)
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($TenantId))
+    {
+        $matchers += (New-BHOGPropertyMatcher -Key 'tenantid' -Value $TenantId)
+    }
+
+    $matchers
+}
+
 function Resolve-GitHoundScimIdpCorrelations
 {
     [CmdletBinding()]
@@ -1297,21 +1319,29 @@ function Resolve-GitHoundScimIdpCorrelations
     }
 
     $contexts = @($samlProviderNodes | ForEach-Object { Get-GitHoundSamlProviderContext -SamlProviderNode $_ })
-    $oktaContexts = @($contexts | Where-Object { $_.IdpKind -eq 'okta' })
-    if (-not $oktaContexts) {
+    $supportedContexts = @($contexts | Where-Object { $_.IdpKind -in @('okta', 'azure') })
+    if (-not $supportedContexts) {
         return [PSCustomObject]@{ Nodes = @(); Edges = $edges }
     }
 
-    foreach ($context in $oktaContexts) {
+    foreach ($context in $supportedContexts) {
         if ($context.SupportsScimUsers) {
             foreach ($scimUser in @($ScimResult.Nodes | Where-Object { $_.kinds -contains 'SCIM_User' })) {
                 if (($scimUser.properties.enabled -eq $true) -and -not [string]::IsNullOrWhiteSpace($scimUser.properties.externalId)) {
-                    $null = $edges.Add((New-GitHoundEdge -Kind 'SCIM_Provisioned' -StartId $scimUser.properties.externalId -StartKind 'Okta_User' -EndId $scimUser.id -Properties @{ traversable = $true }))
+                    switch ($context.IdpKind) {
+                        'okta' {
+                            $null = $edges.Add((New-GitHoundEdge -Kind 'SCIM_Provisioned' -StartId $scimUser.properties.externalId -StartKind 'Okta_User' -EndId $scimUser.id -Properties @{ traversable = $true }))
+                        }
+                        'azure' {
+                            $azureUserMatchers = Get-GitHoundAzureUserPropertyMatchers -ObjectId $scimUser.properties.externalId -TenantId $context.ForeignEnvironmentId
+                            $null = $edges.Add((New-GitHoundEdge -Kind 'SCIM_Provisioned' -StartKind 'AZUser' -StartPropertyMatchers $azureUserMatchers -EndId $scimUser.id -Properties @{ traversable = $true }))
+                        }
+                    }
                 }
             }
         }
 
-        if ($context.SupportsScimGroups -and -not [string]::IsNullOrWhiteSpace($context.ForeignEnvironmentId)) {
+        if ($context.IdpKind -eq 'okta' -and $context.SupportsScimGroups -and -not [string]::IsNullOrWhiteSpace($context.ForeignEnvironmentId)) {
             foreach ($scimGroup in @($ScimResult.Nodes | Where-Object { $_.kinds -contains 'SCIM_Group' })) {
                 if (-not [string]::IsNullOrWhiteSpace($scimGroup.properties.externalId)) {
                     $oktaGroupMatchers = Get-GitHoundOktaGroupPropertyMatchers -Name $scimGroup.properties.externalId -OktaDomain $context.ForeignEnvironmentId
@@ -9658,25 +9688,35 @@ function Invoke-GitHound
     } | ConvertTo-Json -Depth 10 | Out-File -FilePath $consolidatedFile
     Write-Host "[+] Consolidated payload: $consolidatedFile ($($filteredNodes.Count) nodes, $($filteredEdges.Count) edges)"
 
-    $hexSamlPayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredSamlNodes -Edges $filteredSamlEdges -IdMap $orgOutputIdMap
-    [PSCustomObject]@{
-        '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
-        graph = [PSCustomObject]@{
-            nodes = $hexSamlPayload.Nodes
-            edges = $hexSamlPayload.Edges
-        }
-    } | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_saml_$orgId.json")
-
-    if ($CollectAll) {
-        $hexScimPayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredScimNodes -Edges $filteredScimEdges -IdMap $orgOutputIdMap
+    $orgSamlFilePath = Join-Path $CheckpointPath "githound_saml_$orgId.json"
+    if ($filteredSamlNodes.Count -gt 0 -or $filteredSamlEdges.Count -gt 0) {
+        $hexSamlPayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredSamlNodes -Edges $filteredSamlEdges -IdMap $orgOutputIdMap
         [PSCustomObject]@{
             '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
             graph = [PSCustomObject]@{
-                nodes = $hexScimPayload.Nodes
-                edges = $hexScimPayload.Edges
+                nodes = $hexSamlPayload.Nodes
+                edges = $hexSamlPayload.Edges
             }
-        } | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_scim_$orgId.json")
-        Write-Host "[+] SCIM payload: githound_scim_$orgId.json ($($filteredScimNodes.Count) nodes, $($filteredScimEdges.Count) edges)"
+        } | ConvertTo-Json -Depth 10 | Out-File -FilePath $orgSamlFilePath
+    } elseif (Test-Path $orgSamlFilePath) {
+        Remove-Item $orgSamlFilePath -Force
+    }
+
+    if ($CollectAll) {
+        $orgScimFilePath = Join-Path $CheckpointPath "githound_scim_$orgId.json"
+        if ($filteredScimNodes.Count -gt 0 -or $filteredScimEdges.Count -gt 0) {
+            $hexScimPayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredScimNodes -Edges $filteredScimEdges -IdMap $orgOutputIdMap
+            [PSCustomObject]@{
+                '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
+                graph = [PSCustomObject]@{
+                    nodes = $hexScimPayload.Nodes
+                    edges = $hexScimPayload.Edges
+                }
+            } | ConvertTo-Json -Depth 10 | Out-File -FilePath $orgScimFilePath
+            Write-Host "[+] SCIM payload: githound_scim_$orgId.json ($($filteredScimNodes.Count) nodes, $($filteredScimEdges.Count) edges)"
+        } elseif (Test-Path $orgScimFilePath) {
+            Remove-Item $orgScimFilePath -Force
+        }
     }
 
     if ($filteredOidcEdges.Count -gt 0) {
@@ -9990,26 +10030,36 @@ function Invoke-GitHoundEnterprise
     $enterpriseOutputIdMap = Get-GitHoundHexObjectIdMap -Nodes @($filteredNodes + $filteredEnterpriseSamlNodes + $scimNodes)
 
     if ($Session.HasPersonalAccessToken) {
+        $enterpriseSamlFilePath = Join-Path $CheckpointPath "githound_saml_$entId.json"
         $hexEnterpriseSamlPayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredEnterpriseSamlNodes -Edges $filteredEnterpriseSamlEdges -IdMap $enterpriseOutputIdMap
-        $enterpriseSamlPayload = [PSCustomObject]@{
-            '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
-            graph = [PSCustomObject]@{
-                nodes = $hexEnterpriseSamlPayload.Nodes
-                edges = $hexEnterpriseSamlPayload.Edges
+        if ($filteredEnterpriseSamlNodes.Count -gt 0 -or $filteredEnterpriseSamlEdges.Count -gt 0) {
+            $enterpriseSamlPayload = [PSCustomObject]@{
+                '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
+                graph = [PSCustomObject]@{
+                    nodes = $hexEnterpriseSamlPayload.Nodes
+                    edges = $hexEnterpriseSamlPayload.Edges
+                }
             }
+            $enterpriseSamlPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath $enterpriseSamlFilePath
+        } elseif (Test-Path $enterpriseSamlFilePath) {
+            Remove-Item $enterpriseSamlFilePath -Force
         }
-        $enterpriseSamlPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_saml_$entId.json")
 
-        $hexEnterpriseScimPayload = Convert-GitHoundOutputWithIdMap -Nodes $scimNodes -Edges $scimEdges -IdMap $enterpriseOutputIdMap
-        $scimPayload = [PSCustomObject]@{
-            '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
-            graph = [PSCustomObject]@{
-                nodes = $hexEnterpriseScimPayload.Nodes
-                edges = $hexEnterpriseScimPayload.Edges
+        $enterpriseScimFilePath = Join-Path $CheckpointPath "githound_scim_$entId.json"
+        if ($scimNodes.Count -gt 0 -or $scimEdges.Count -gt 0) {
+            $hexEnterpriseScimPayload = Convert-GitHoundOutputWithIdMap -Nodes $scimNodes -Edges $scimEdges -IdMap $enterpriseOutputIdMap
+            $scimPayload = [PSCustomObject]@{
+                '$schema' = "https://raw.githubusercontent.com/MichaelGrafnetter/EntraAuthPolicyHound/refs/heads/main/bloodhound-opengraph.schema.json"
+                graph = [PSCustomObject]@{
+                    nodes = $hexEnterpriseScimPayload.Nodes
+                    edges = $hexEnterpriseScimPayload.Edges
+                }
             }
+            $scimPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath $enterpriseScimFilePath
+            Write-Host "[+] SCIM payload: githound_scim_$entId.json ($($scimNodes.Count) nodes, $($scimEdges.Count) edges)"
+        } elseif (Test-Path $enterpriseScimFilePath) {
+            Remove-Item $enterpriseScimFilePath -Force
         }
-        $scimPayload | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $CheckpointPath "githound_scim_$entId.json")
-        Write-Host "[+] SCIM payload: githound_scim_$entId.json ($($scimNodes.Count) nodes, $($scimEdges.Count) edges)"
     }
     $hexEnterprisePayload = Convert-GitHoundOutputWithIdMap -Nodes $filteredNodes -Edges $filteredEdges -IdMap $enterpriseOutputIdMap
     $enterprisePayload = [PSCustomObject]@{


### PR DESCRIPTION
- only write organization-level SAML sidecar output when SAML nodes or edges exist at that scope
- only write organization-level SCIM sidecar output when SCIM nodes or edges exist at that scope
- only write enterprise-level SAML sidecar output when SAML nodes or edges exist at that scope
- only write enterprise-level SCIM sidecar output when SCIM nodes or edges exist at that scope
- remove stale sidecar files from prior runs when the current scoped payload is empty

- update SCIM/SAML provider comparison notes to clarify:
  - org-level SCIM does not support Group -> Team mappings because of a GitHub product limitation
  - Entra user hybrid edges are supported through Resolve-GitHoundScimIdpCorrelations